### PR TITLE
Fetch and Publish System Status Info

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: astarte-platform/astarte-device-sdk-esp32
+          ref: release-1.0
           path: ./examples/edgehog_app/components/astarte-device-sdk-esp32
       - name: Build with idf.py
         run: |

--- a/examples/edgehog_app/README.md
+++ b/examples/edgehog_app/README.md
@@ -7,7 +7,7 @@
 * Add Astarte component
 
     ``` bash
-    git clone https://github.com/astarte-platform/astarte-device-sdk-esp32.git ./components/astarte-device-sdk-esp32
+    git clone https://github.com/astarte-platform/astarte-device-sdk-esp32.git -b release-1.0 ./components/astarte-device-sdk-esp32
     ```
 ### Configure the project
 

--- a/examples/edgehog_app/main/main.c
+++ b/examples/edgehog_app/main/main.c
@@ -112,5 +112,5 @@ void app_main(void)
         return;
     }
 
-    edgehog_init(astarte_device);
+    edgehog_new(astarte_device);
 }

--- a/include/edgehog.h
+++ b/include/edgehog.h
@@ -19,13 +19,30 @@
 #ifndef EDGEHOG_H
 #define EDGEHOG_H
 
+typedef struct edgehog_device_t *edgehog_device_handle_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <astarte_device.h>
+/**
+ * @brief create Edgehog device handle.
+ *
+ * @details This function creates an Edgehog device handle. It must be called before anything else.
+ * @param astarte_device A valid Astarte device handle.
+ * @return The handle to the device, NULL if an error occurred.
+ */
 
-void edgehog_init(astarte_device_handle_t astarte_device);
+edgehog_device_handle_t edgehog_new(astarte_device_handle_t astarte_device);
+
+/**
+ * @brief destroy Edgehog device.
+ *
+ * @details This function destroys the device, freeing all its resources.
+ * @param edgehog_device A valid Edgehog device handle.
+ */
+void edgehog_device_destroy(edgehog_device_handle_t edgehog_device);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION

- Publish System Status Info to remote Astarte instance using io.edgehog.devicemanager.SystemStatus interface.
- Add edgehog_device_handle to interact with edgehog_device api.