### PR TITLE
Add OTA support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
-set(edgehog_srcs "src/edgehog_device.c")
+set(edgehog_srcs "src/edgehog_device.c"
+        "src/edgehog_ota.c")
 
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"
-        REQUIRES astarte-device-sdk-esp32 nvs_flash)
+        PRIV_INCLUDE_DIRS "private"
+        REQUIRES astarte-device-sdk-esp32 nvs_flash app_update esp_https_ota)

--- a/examples/edgehog_app/CMakeLists.txt
+++ b/examples/edgehog_app/CMakeLists.txt
@@ -5,5 +5,5 @@ cmake_minimum_required(VERSION 3.5)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
-
+set(PROJECT_VER "0.1.0")
 project(edgehog-app)

--- a/examples/edgehog_app/README.md
+++ b/examples/edgehog_app/README.md
@@ -30,6 +30,24 @@ If you have deployed Astarte through docker-compose, the Astarte Pairing base UR
 a common, standard installation, the base URL can be built by adding `/pairing` to your API base URL, e.g.
 `https://api.astarte.example.com/pairing`.
 
+## OTA
+The OTA update mechanism allows a device to update itself. It is based on
+`esp_https_ota` that provides simplified APIs to perform firmware upgrades
+over HTTPS.
+
+OTA requires configuring the Partition Table of the device with at least
+two `OTA app slot` partitions (i.e. ota_0 and ota_1) and an `OTA Data Partition`.
+
+The simplest way to use the partition table with OTA is to open the project configuration
+menu (idf.py menuconfig) and choose partition tables under CONFIG_PARTITION_TABLE_TYPE selecting
+`Factory app, two OTA definitions` or create a custom Partition Table.
+
+The OTA operation functions write a new app firmware image to whichever OTA app
+slot that is currently not selected for booting. Once the image is verified, the
+OTA Data partition is updated to specify that this image should be used for the next boot.
+
+[see EPS OTA](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/ota.html)
+
 ### Build and Flash
 
 Build the project and flash it to the board, then run the monitor tool to view the serial output:

--- a/include/edgehog.h
+++ b/include/edgehog.h
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_H
+#define EDGEHOG_H
+
+#define ASTARTE_UUID_LEN 39
+
+// clang-format off
+
+/**
+ * @brief Edgehog return codes.
+ *
+ * @detail Edgehog Device SDK return codes. EDGEHOG_OK is always returned when no errors occurred.
+ */
+typedef enum
+{
+    EDGEHOG_OK = 0, /**< No errors. */
+    EDGEHOG_ERR = 1, /**< A generic error occurred. This is usually an internal error in the SDK */
+    EDGEHOG_ERR_NETWORK = 2, /**< A generic network error occurred. */
+    EDGEHOG_ERR_NVS = 3, /**< A generic error occurred when dealing with NVS */
+    EDGEHOG_ERR_OTA_ALREADY_IN_PROGRESS = 4, /**< Attempted to perform OTA operation while there is another one already active*/
+    EDGEHOG_ERR_OTA_FAILED = 5, /**< An error occurred during OTA procedure */
+    EDGEHOG_ERR_OTA_DEPLOY = 6, /**< An error occurred during OTA Deploy procedure */
+    EDGEHOG_ERR_OTA_WRONG_PARTITION = 7, /**< The OTA procedure boot on the wrong partition */
+}edgehog_err_t;
+
+// clang-format on
+
+#endif // EDGEHOG_H

--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -25,8 +25,10 @@ typedef struct edgehog_device_t *edgehog_device_handle_t;
 extern "C" {
 #endif
 
+#include "edgehog.h"
 #include <astarte_device.h>
 #include <esp_err.h>
+#include <nvs.h>
 
 /**
  * @brief Edgehog device configuration struct
@@ -95,8 +97,19 @@ esp_err_t edgehog_device_set_appliance_serial_number(
 esp_err_t edgehog_device_set_appliance_part_number(
     edgehog_device_handle_t edgehog_device, const char *part_num);
 
+/**
+ * @brief receive data from Astarte Server.
+ *
+ * @details This function must be called when an Astarte Data event coming from server.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ * @param event A valid Astarte device data event.
+ */
+void edgehog_device_astarte_event_handler(
+    edgehog_device_handle_t edgehog_device, astarte_device_data_event_t *event);
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif // EDGEHOG_H
+#endif // EDGEHOG_DEVICE_H

--- a/private/edgehog_device_private.h
+++ b/private/edgehog_device_private.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_DEVICE_PRIVATE_H
+#define EDGEHOG_DEVICE_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "edgehog_device.h"
+
+/**
+ * @brief open the Edgehog non-volatile storage with a given namespace.
+ *
+ * @details This function open an Edgehog non-volatile storage with a given namespace
+ * from specified partition defined in the edgehog_device_config_t.
+ *
+ * @param[in] edgehog_device A valid Edgehog device handle.
+ * @param[in] name Namespace name.
+ * @param[out] out_handle If successful (return code is zero), handle will be
+ *                        returned in this argument.
+ * @return ESP_OK if storage handle was opened successfully, an esp_err_t otherwise.
+ */
+esp_err_t edgehog_device_nvs_open(
+    edgehog_device_handle_t edgehog_device, char *name, nvs_handle_t *out_handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EDGEHOG_DEVICE_PRIVATE_H

--- a/private/edgehog_ota.h
+++ b/private/edgehog_ota.h
@@ -1,0 +1,76 @@
+/*
+* This file is part of Edgehog.
+*
+* Copyright 2021 SECO Mind Srl
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef EDGEHOG_OTA_H
+#define EDGEHOG_OTA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "edgehog_device.h"
+
+const static astarte_interface_t ota_request_interface
+    = { .name = "io.edgehog.devicemanager.OTARequest",
+          .major_version = 0,
+          .minor_version = 1,
+          .ownership = OWNERSHIP_SERVER,
+          .type = TYPE_DATASTREAM };
+
+const static astarte_interface_t ota_response_interface
+    = { .name = "io.edgehog.devicemanager.OTAResponse",
+          .major_version = 0,
+          .minor_version = 1,
+          .ownership = OWNERSHIP_DEVICE,
+          .type = TYPE_DATASTREAM };
+
+/**
+ * @brief initialize Edgehog device OTA.
+ *
+ * @details This function initializes the OTA procedure and
+ * if there is any pending OTA it completes it.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ * @param astarte_device A valid Astarte device handle.
+ */
+
+void edgehog_ota_init(
+    edgehog_device_handle_t edgehog_device, astarte_device_handle_t astarte_device);
+
+/**
+ * @brief receive Edgehog device OTA.
+ *
+ * @details This function receives an OTA event request from Astarte,
+ * internally call do_ota function which is blocking, the calling
+ * task will be blocked until the OTA procedure completes.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ * @param astarte_device A valid Astarte device handle.
+ * @param event_request A valid Astarte device data event.
+ *
+ * @return EDGEHOG_OK if the OTA event is handled successfully, an edgehog_err_t otherwise.
+ */
+
+edgehog_err_t edgehog_ota_event(edgehog_device_handle_t edgehog_device,
+    astarte_device_handle_t astarte_device, astarte_device_data_event_t *event_request);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EDGEHOG_OTA_H

--- a/src/edgehog_ota.c
+++ b/src/edgehog_ota.c
@@ -1,0 +1,333 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_ota.h"
+#include "edgehog_device_private.h"
+#include <astarte_bson.h>
+#include <astarte_bson_serializer.h>
+#include <astarte_bson_types.h>
+#include <esp_err.h>
+#include <esp_https_ota.h>
+#include <esp_log.h>
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
+#include <freertos/task.h>
+#include <nvs.h>
+
+#define OTA_REQ_TIMEOUT_MS (60 * 1000)
+#define MAX_OTA_RETRY 5
+#define OTA_NAMESPACE "edgehog_ota"
+#define OTA_STATE_KEY "state"
+#define OTA_PARTITION_ADDR_KEY "part_id"
+#define OTA_REQUEST_ID_KEY "req_id"
+
+static const char *TAG = "EDGEHOG_OTA";
+
+typedef enum
+{
+    OTA_IDLE,
+    OTA_DOWNLOAD_DEPLOY,
+    OTA_REBOOT,
+    OTA_FAILED,
+    OTA_SUCCESS
+} edgehog_ota_state;
+
+static bool is_partition_changed(nvs_handle handle);
+static void publish_ota_data(astarte_device_handle_t astarte_device, const char *request_uuid,
+    edgehog_ota_state state, edgehog_err_t error);
+/**
+ * This function is blocking, the calling task will be blocked until the OTA procedure completes.
+ */
+static edgehog_err_t do_ota(edgehog_device_handle_t edgehog_device,
+    astarte_device_handle_t astarte_device, const char *request_uuid, const char *ota_url);
+static void ota_state_reboot(nvs_handle handle);
+static void ota_state_failed(astarte_device_handle_t astarte_device, nvs_handle handle,
+    const char *request_uuid, edgehog_err_t ota_result);
+static const char *edgehog_ota_state_to_string(edgehog_ota_state state);
+static const char *edgehog_err_to_code(edgehog_err_t error);
+
+static esp_err_t http_ota_event_handler(esp_http_client_event_t *evt)
+{
+    switch (evt->event_id) {
+        case HTTP_EVENT_ERROR:
+            break;
+        case HTTP_EVENT_ON_CONNECTED:
+            ESP_LOGD(TAG, "CONNECTED");
+            break;
+        case HTTP_EVENT_HEADER_SENT:
+            break;
+        case HTTP_EVENT_ON_HEADER:
+            ESP_LOGD(
+                TAG, "HTTP_EVENT_ON_HEADER, key=%s, value=%s", evt->header_key, evt->header_value);
+            break;
+        case HTTP_EVENT_ON_DATA:
+            break;
+        case HTTP_EVENT_ON_FINISH:
+            ESP_LOGD(TAG, "DOWNLOAD FINISHED");
+            break;
+        case HTTP_EVENT_DISCONNECTED:
+            ESP_LOGD(TAG, "DISCONNECTED");
+            break;
+    }
+    return ESP_OK;
+}
+
+void edgehog_ota_init(
+    edgehog_device_handle_t edgehog_device, astarte_device_handle_t astarte_device)
+{
+    nvs_handle_t handle;
+    esp_err_t result = edgehog_device_nvs_open(edgehog_device, OTA_NAMESPACE, &handle);
+
+    if (result == ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(TAG, "Missing OTA namespace in NVS, if there is no pending OTA ignore it");
+        return;
+    }
+
+    char req_uuid[ASTARTE_UUID_LEN];
+    size_t req_uuid_size = sizeof(ASTARTE_UUID_LEN);
+    result = nvs_get_str(handle, OTA_REQUEST_ID_KEY, req_uuid, &req_uuid_size);
+
+    if (result != ESP_OK) {
+        goto end;
+    }
+
+    uint8_t ota_state = OTA_IDLE;
+    result = nvs_get_u8(handle, OTA_STATE_KEY, &ota_state);
+
+    if (result != ESP_OK || ota_state != OTA_REBOOT) {
+        nvs_set_u8(handle, OTA_STATE_KEY, OTA_FAILED);
+        nvs_commit(handle);
+        publish_ota_data(astarte_device, req_uuid, OTA_FAILED, EDGEHOG_ERR);
+        goto end;
+    }
+
+    if (is_partition_changed(handle)) {
+        publish_ota_data(astarte_device, req_uuid, OTA_SUCCESS, EDGEHOG_OK);
+    } else {
+        ESP_LOGE(TAG, "Unable to switch into updated partition");
+        nvs_set_u8(handle, OTA_STATE_KEY, OTA_FAILED);
+        nvs_commit(handle);
+        publish_ota_data(astarte_device, req_uuid, OTA_FAILED, EDGEHOG_ERR_OTA_WRONG_PARTITION);
+    }
+
+end:
+    nvs_erase_key(handle, OTA_REQUEST_ID_KEY);
+    nvs_set_u8(handle, OTA_STATE_KEY, OTA_IDLE);
+    nvs_commit(handle);
+    nvs_close(handle);
+}
+
+// Beware this function blocks the caller until OTA is completed.
+edgehog_err_t edgehog_ota_event(edgehog_device_handle_t edgehog_device,
+    astarte_device_handle_t astarte_device, astarte_device_data_event_t *event_request)
+{
+    if (event_request->bson_value_type != BSON_TYPE_DOCUMENT) {
+        ESP_LOGE(TAG, "Unable to handle ota request, type not supported");
+        return EDGEHOG_ERR;
+    }
+
+    uint8_t type;
+    size_t str_value_len;
+
+    const void *found = astarte_bson_key_lookup("uuid", event_request->bson_value, &type);
+    const char *request_uuid = astarte_bson_value_to_string(found, &str_value_len);
+    if (!request_uuid || type != BSON_TYPE_STRING) {
+        ESP_LOGE(TAG, "Unable to extract requestUUID from bson");
+        return EDGEHOG_ERR;
+    }
+
+    found = astarte_bson_key_lookup("url", event_request->bson_value, &type);
+    const char *ota_url = astarte_bson_value_to_string(found, &str_value_len);
+    if (!ota_url || type != BSON_TYPE_STRING) {
+        ESP_LOGE(TAG, "Unable to extract URL from bson");
+        return EDGEHOG_ERR;
+    }
+
+    // Beware this function blocks the caller until OTA is completed.
+    return do_ota(edgehog_device, astarte_device, request_uuid, ota_url);
+}
+
+// TODO: make this function async using advanced_esp_ota instead of esp_https_ota
+static edgehog_err_t do_ota(edgehog_device_handle_t edgehog_device,
+    astarte_device_handle_t astarte_device, const char *request_uuid, const char *ota_url)
+{
+    ESP_LOGI(TAG, "INIT");
+    nvs_handle_t handle;
+    esp_err_t esp_ret = edgehog_device_nvs_open(edgehog_device, OTA_NAMESPACE, &handle);
+
+    if (esp_ret != ESP_OK && esp_ret != ESP_ERR_NOT_FOUND) {
+        ESP_LOGE(TAG, "Unable to open NVS to save ota state, ota cancelled");
+        publish_ota_data(astarte_device, request_uuid, OTA_FAILED, EDGEHOG_ERR_NVS);
+        goto error;
+    }
+
+    uint8_t ota_state = OTA_IDLE;
+    esp_ret = nvs_get_u8(handle, OTA_STATE_KEY, &ota_state);
+
+    if (esp_ret == ESP_OK && ota_state != OTA_IDLE) {
+        ESP_LOGE(TAG, "Unable to do OTA Operation, OTA already in progress");
+        publish_ota_data(
+            astarte_device, request_uuid, OTA_FAILED, EDGEHOG_ERR_OTA_ALREADY_IN_PROGRESS);
+        goto error;
+    }
+
+    esp_ret = nvs_set_str(handle, OTA_REQUEST_ID_KEY, request_uuid);
+    nvs_commit(handle);
+
+    if (esp_ret != ESP_OK && esp_ret != ESP_ERR_NOT_FOUND) {
+        ESP_LOGE(TAG, "Unable to write OTA request_uuid into NVS, ota cancelled");
+        publish_ota_data(astarte_device, request_uuid, OTA_FAILED, EDGEHOG_ERR_NVS);
+        goto error;
+    }
+
+    ota_state = OTA_DOWNLOAD_DEPLOY;
+    publish_ota_data(astarte_device, request_uuid, ota_state, EDGEHOG_OK);
+    nvs_set_u8(handle, OTA_STATE_KEY, ota_state);
+    nvs_commit(handle);
+
+    ESP_LOGI(TAG, "DOWNLOAD_AND_DEPLOY");
+    esp_http_client_config_t config = {
+        .url = ota_url,
+        .event_handler = http_ota_event_handler,
+        .timeout_ms = OTA_REQ_TIMEOUT_MS,
+    };
+
+    uint8_t attempts = 0;
+    // FIXME: this function is blocking
+    esp_ret = esp_https_ota(&config);
+    while (attempts < MAX_OTA_RETRY && esp_ret != ESP_OK) {
+        vTaskDelay(pdMS_TO_TICKS(attempts * 2000));
+        attempts++;
+        ESP_LOGW(TAG, "! OTA FAILED, ATTEMPT #%d !", attempts);
+        esp_ret = esp_https_ota(&config);
+    }
+
+    ESP_LOGI(TAG, "RESULT %s", esp_err_to_name(esp_ret));
+
+    edgehog_err_t ota_result;
+    switch (esp_ret) {
+        case ESP_OK:
+            ota_result = EDGEHOG_OK;
+            ota_state_reboot(handle);
+            break;
+        case ESP_ERR_INVALID_ARG:
+            ota_result = EDGEHOG_ERR_NETWORK;
+            ota_state_failed(astarte_device, handle, request_uuid, ota_result);
+            break;
+        case ESP_ERR_OTA_VALIDATE_FAILED:
+        case ESP_ERR_INVALID_SIZE:
+        case ESP_ERR_NO_MEM:
+        case ESP_ERR_FLASH_OP_TIMEOUT:
+        case ESP_ERR_FLASH_OP_FAIL:
+        case ESP_ERR_FLASH_BASE:
+            ota_result = EDGEHOG_ERR_OTA_DEPLOY;
+            ota_state_failed(astarte_device, handle, request_uuid, ota_result);
+            break;
+        default:
+            ota_result = EDGEHOG_ERR_OTA_FAILED;
+            ota_state_failed(astarte_device, handle, request_uuid, ota_result);
+    }
+
+    nvs_close(handle);
+    return ota_result;
+
+error:
+    nvs_close(handle);
+    return EDGEHOG_ERR_OTA_FAILED;
+}
+
+static void ota_state_reboot(nvs_handle handle)
+{
+    nvs_set_u8(handle, OTA_STATE_KEY, OTA_REBOOT);
+    nvs_commit(handle);
+    const esp_partition_t *partition_info = (esp_partition_t *) esp_ota_get_running_partition();
+    nvs_set_u32(handle, OTA_PARTITION_ADDR_KEY, partition_info->address);
+    nvs_commit(handle);
+}
+
+static void ota_state_failed(astarte_device_handle_t astarte_device, nvs_handle handle,
+    const char *request_uuid, edgehog_err_t ota_result)
+{
+    ESP_LOGW(TAG, "OTA FAILED");
+    nvs_set_u8(handle, OTA_STATE_KEY, OTA_FAILED);
+    nvs_commit(handle);
+    publish_ota_data(astarte_device, request_uuid, OTA_FAILED, ota_result);
+    nvs_set_u8(handle, OTA_STATE_KEY, OTA_IDLE);
+    nvs_commit(handle);
+}
+
+static void publish_ota_data(astarte_device_handle_t astarte_device, const char *request_uuid,
+    edgehog_ota_state state, edgehog_err_t error)
+{
+    const char *str_ota_state = edgehog_ota_state_to_string(state);
+    const char *status_code = edgehog_err_to_code(error);
+
+    struct astarte_bson_serializer_t bs;
+    astarte_bson_serializer_init(&bs);
+    astarte_bson_serializer_append_string(&bs, "uuid", request_uuid);
+    astarte_bson_serializer_append_string(&bs, "status", str_ota_state);
+    astarte_bson_serializer_append_string(&bs, "statusCode", status_code);
+    astarte_bson_serializer_append_end_of_document(&bs);
+
+    int doc_len;
+    const void *doc = astarte_bson_serializer_get_document(&bs, &doc_len);
+    astarte_device_stream_aggregate(
+        astarte_device, ota_response_interface.name, "/response", doc, 0);
+    astarte_bson_serializer_destroy(&bs);
+}
+
+static bool is_partition_changed(nvs_handle handle)
+{
+    const esp_partition_t *partition_info = esp_ota_get_running_partition();
+    uint32_t prev_partition_addr;
+
+    esp_err_t result = nvs_get_u32(handle, OTA_PARTITION_ADDR_KEY, &prev_partition_addr);
+    return result == ESP_OK && prev_partition_addr != partition_info->address;
+}
+
+static const char *edgehog_ota_state_to_string(edgehog_ota_state state)
+{
+    switch (state) {
+        case OTA_FAILED:
+            return "Error";
+        case OTA_SUCCESS:
+            return "Done";
+        default:
+            return "InProgress";
+    }
+}
+
+static const char *edgehog_err_to_code(edgehog_err_t error)
+{
+    switch (error) {
+        case EDGEHOG_ERR_NETWORK:
+            return "OTAErrorNetwork";
+        case EDGEHOG_ERR_NVS:
+            return "OTAErrorNvs";
+        case EDGEHOG_ERR_OTA_ALREADY_IN_PROGRESS:
+            return "OTAAlreadyInProgress";
+        case EDGEHOG_ERR_OTA_FAILED:
+            return "OTAFailed";
+        case EDGEHOG_ERR_OTA_DEPLOY:
+            return "OTAErrorDeploy";
+        case EDGEHOG_ERR_OTA_WRONG_PARTITION:
+            return "OTAErrorBootWrongPartition";
+        default:
+            return "";
+    }
+}


### PR DESCRIPTION
- The OTA update mechanism allows a device to update itself,It is based on **esp_https_ota** that provides simplified APIs to perform firmware upgrades over HTTPS.
- The OTA data is received via the `io.edgehog.devicemanager.OTARequest` interface.
- Publish OTA status to remote Astarte instance using `io.edgehog.devicemanager.OTAResponse` interface.

Closes #13