### PR TITLE
Refactor edgehog into edgehog_device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(edgehog_srcs "src/edgehog.c")
+set(edgehog_srcs "src/edgehog_device.c")
 
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"

--- a/examples/edgehog_app/main/main.c
+++ b/examples/edgehog_app/main/main.c
@@ -1,4 +1,4 @@
-#include "edgehog.h"
+#include "edgehog_device.h"
 #include <astarte_credentials.h>
 #include <esp_log.h>
 #include <esp_system.h>
@@ -7,6 +7,7 @@
 #include <nvs_flash.h>
 
 #define WIFI_CONNECTED_BIT BIT0
+#define NVS_PARTITION "nvs"
 
 static const char *TAG = "CORE_WIFI";
 static EventGroupHandle_t wifi_event_group;
@@ -116,7 +117,7 @@ void app_main(void)
 
     edgehog_device_config_t edgehog_conf
         = { .astarte_device = astarte_device, .partition_label = "nvs" };
-    edgehog_device_handle_t edgehog_device = edgehog_new(&edgehog_conf);
+    edgehog_device_handle_t edgehog_device = edgehog_device_new(&edgehog_conf);
 
     edgehog_device_set_appliance_serial_number(edgehog_device, "serial_number_1");
     edgehog_device_set_appliance_part_number(edgehog_device, "part_number_1");

--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-#ifndef EDGEHOG_H
-#define EDGEHOG_H
+#ifndef EDGEHOG_DEVICE_H
+#define EDGEHOG_DEVICE_H
 
 typedef struct edgehog_device_t *edgehog_device_handle_t;
 
@@ -31,7 +31,7 @@ extern "C" {
 /**
  * @brief Edgehog device configuration struct
  *
- * @details This struct is used to collect all the data needed by the edgehog_new function.
+ * @details This struct is used to collect all the data needed by the edgehog_device_new function.
  * Pay attention that astarte_device is required and must not be null, while partition_label is
  * completely optional. If no partition label is provided, NVS_DEFAULT_PART_NAME will be used.
  * The values provided with this struct are not copied, do not free() them before calling
@@ -55,13 +55,13 @@ typedef struct
  *      .astarte_device = astarte_device,
  *  };
  *
- *  edgehog_device_handle_t edgehog_device = edgehog_new(&edgehog_conf);
+ *  edgehog_device_handle_t edgehog_device = edgehog_device_new(&edgehog_conf);
  *
  * @param config An edgehog_device_config_t struct.
  * @return The handle to the device, NULL if an error occurred.
  */
 
-edgehog_device_handle_t edgehog_new(edgehog_device_config_t *config);
+edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config);
 
 /**
  * @brief destroy Edgehog device.

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "edgehog.h"
+#include "edgehog_device.h"
 #include "esp_system.h"
 #include <astarte_bson_serializer.h>
 #include <esp_err.h>
@@ -70,7 +70,7 @@ const static astarte_interface_t appliance_info_interface
           .ownership = OWNERSHIP_DEVICE,
           .type = TYPE_PROPERTIES };
 
-esp_err_t add_interfaces(astarte_device_handle_t astarte_device);
+static esp_err_t add_interfaces(astarte_device_handle_t astarte_device);
 static void publish_device_hardware_info(astarte_device_handle_t astarte_device);
 static void publish_system_status(edgehog_device_handle_t edgehog_device);
 static void publish_wifi_ap(edgehog_device_handle_t edgehog_device);
@@ -97,7 +97,7 @@ static void edgehog_event_handler(
     }
 }
 
-edgehog_device_handle_t edgehog_new(edgehog_device_config_t *config)
+edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
 {
     if (!config) {
         ESP_LOGE(TAG, "Unable to init Edgehog device, no config provided");
@@ -252,7 +252,7 @@ static void scan_wifi_ap(edgehog_device_handle_t edgehog_device)
     if (ret != ESP_OK) {
         ESP_LOGE(TAG,
             "Unable to register to default event loop. Be sure to have called "
-            "esp_event_loop_create_default() before calling edgehog_new");
+            "esp_event_loop_create_default() before calling edgehog_device_new");
         return;
     }
 
@@ -322,6 +322,7 @@ static esp_err_t edgehog_nvs_set_str(const char *partition_name, const char *key
         return ret;
     }
 
+    nvs_commit(nvs);
     nvs_close(nvs);
     return ESP_OK;
 }


### PR DESCRIPTION
- Change filename and function naming of edgehog.
- All public functions in edgehog_device now start with **edgehog_device.**
