### PR TITLE
Add telemetry example

### DIFF
--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -108,6 +108,25 @@ esp_err_t edgehog_device_set_appliance_part_number(
 void edgehog_device_astarte_event_handler(
     edgehog_device_handle_t edgehog_device, astarte_device_data_event_t *event);
 
+typedef enum
+{
+    EH_TM_ALL, /**< telemetry: all */
+    EH_TM_SYSTEM, /**< telemetry: system */
+    EH_TM_LOCATION, /**< telemetry: location */
+} edgehog_device_telemetry_type_t;
+
+/**
+ * @brief publish Edgehog telemetry.
+ *
+ * @details This function sends the Edgehog telemetry,
+ * according to the selected type;
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ * @param type Edgehog telemetry type.
+ */
+void edgehog_device_publish_telemetry(
+    edgehog_device_handle_t edgehog_device, edgehog_device_telemetry_type_t type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -473,3 +473,23 @@ esp_err_t edgehog_device_nvs_open(
 
     return ESP_OK;
 }
+
+void edgehog_device_publish_telemetry(
+    edgehog_device_handle_t edgehog_device, edgehog_device_telemetry_type_t type)
+{
+    if (!edgehog_device) {
+        return;
+    }
+
+    switch (type) {
+        case EH_TM_SYSTEM:
+            publish_system_status(edgehog_device);
+            break;
+        case EH_TM_LOCATION:
+            scan_wifi_ap(edgehog_device);
+            break;
+        default:
+            publish_system_status(edgehog_device);
+            scan_wifi_ap(edgehog_device);
+    }
+}


### PR DESCRIPTION
- Add telemetry function for publishing all or selected type of telemetry.
- Add example that show how to use telemetry function.