### PR TITLE
Publish battery status info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_ota.c"
-        "src/edgehog_storage_usage.c")
+        "src/edgehog_storage_usage.c"
+        "src/edgehog_battery_status.c")
 
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"

--- a/include/edgehog_battery_status.h
+++ b/include/edgehog_battery_status.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_BATTERY_STATUS_H
+#define EDGEHOG_BATTERY_STATUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "astarte_device.h"
+
+// clang-format off
+
+/**
+ * @brief Edgehog Battery state codes.
+ */
+typedef enum
+{
+    BATTERY_INVALID = 0, /**< The battery state for the device is invalid. */
+    BATTERY_IDLE, /**< The device is plugged into power and the battery is 100% charged. */
+    BATTERY_CHARGING, /**< The device is plugged into power and the battery is less than 100% charged. */
+    BATTERY_DISCHARGING, /**< The device is not plugged into power; the battery is discharging. */
+    BATTERY_IDLE_OR_CHARGING, /**< The battery state for the device cannot be distinguished between "Idle" and "Charging". */
+    BATTERY_FAILURE, /**< A generic failure occurred. */
+    BATTERY_REMOVED, /**< Battery removed from the device */
+    BATTERY_UNKNOWN /**< The battery state for the device cannot be determined. */
+} edgehog_battery_state;
+
+// clang-format on
+
+extern const astarte_interface_t battery_status_interface;
+
+/**
+ * @brief publish Battery status info.
+ *
+ * @details This function publishes battery status info
+ * to Astarte.
+ *
+ * @param astarte_device A valid Astarte device handle.
+ * @param battery_slot Battery slot name.
+ * @param level_percentage Charge level in [0.0%-100.0%] range, such as 89.0%.
+ * @param level_absolute_error The level measurement absolute error in [0.0-100.0] range
+ * @param state Any value of edgehog_battery_state such as `BATTERY_CHARGING`
+ *
+ */
+void edgehog_battery_status_publish(astarte_device_handle_t astarte_device,
+    const char *battery_slot, double level_percentage, double level_absolute_error,
+    edgehog_battery_state state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EDGEHOG_BATTERY_STATUS_H

--- a/src/edgehog_battery_status.c
+++ b/src/edgehog_battery_status.c
@@ -1,0 +1,95 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_battery_status.h"
+#include <astarte_bson_serializer.h>
+#include <esp_log.h>
+#include <stdio.h>
+
+static const char *TAG = "EDGEHOG_BATTERY";
+
+const astarte_interface_t battery_status_interface
+    = { .name = "io.edgehog.devicemanager.BatteryStatus",
+          .major_version = 0,
+          .minor_version = 1,
+          .ownership = OWNERSHIP_DEVICE,
+          .type = TYPE_DATASTREAM };
+
+static const char *edgehog_battery_to_code(edgehog_battery_state state);
+static double normalize_error_level(double level);
+
+void edgehog_battery_status_publish(astarte_device_handle_t astarte_device,
+    const char *battery_slot, double level_percentage, double level_absolute_error,
+    edgehog_battery_state battery_state)
+{
+    const char *battery_status = edgehog_battery_to_code(battery_state);
+    struct astarte_bson_serializer_t bs;
+    astarte_bson_serializer_init(&bs);
+    astarte_bson_serializer_append_double(
+        &bs, "levelPercentage", normalize_error_level(level_percentage));
+    astarte_bson_serializer_append_double(
+        &bs, "levelAbsoluteError", normalize_error_level(level_absolute_error));
+    astarte_bson_serializer_append_string(&bs, "status", battery_status);
+    astarte_bson_serializer_append_end_of_document(&bs);
+
+    size_t path_size = strlen(battery_slot) + 2;
+    char *path = malloc(path_size);
+    if (!path) {
+        ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+        return;
+    }
+    snprintf(path, path_size, "/%s", battery_slot);
+
+    int doc_len;
+    const void *doc = astarte_bson_serializer_get_document(&bs, &doc_len);
+    astarte_device_stream_aggregate(astarte_device, battery_status_interface.name, path, doc, 0);
+    astarte_bson_serializer_destroy(&bs);
+    free(path);
+}
+
+static const char *edgehog_battery_to_code(edgehog_battery_state state)
+{
+    switch (state) {
+        case BATTERY_IDLE:
+            return "Idle";
+        case BATTERY_CHARGING:
+            return "Charging";
+        case BATTERY_DISCHARGING:
+            return "Discharging";
+        case BATTERY_IDLE_OR_CHARGING:
+            return "EitherIdleOrCharging";
+        case BATTERY_FAILURE:
+            return "Failure";
+        case BATTERY_REMOVED:
+            return "Removed";
+        case BATTERY_UNKNOWN:
+            return "Unknown";
+        default:
+            return "";
+    }
+}
+
+static double normalize_error_level(double level)
+{
+    if (level > 100) {
+        return 100;
+    } else if (level < 0) {
+        return 0;
+    }
+    return level;
+}

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "edgehog_battery_status.h"
 #include "edgehog_device_private.h"
 #include "edgehog_ota.h"
 #include "edgehog_storage_usage.h"
@@ -206,6 +207,13 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
             storage_usage_interface.name, ret);
+        return ESP_FAIL;
+    }
+
+    ret = astarte_device_add_interface(device, &battery_status_interface);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
+            battery_status_interface.name, ret);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
Publish Battery status info to remote Astarte instance using `io.edgehog.devicemanager.BatteryStatus` interface.

Closes #21.
