### PR TITLE
Add support to OSInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_ota.c"
         "src/edgehog_storage_usage.c"
         "src/edgehog_battery_status.c"
-        "src/edgehog_command.c")
+        "src/edgehog_command.c"
+        "src/edgehog_os_info.c")
 
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"

--- a/private/edgehog_os_info.h
+++ b/private/edgehog_os_info.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_OS_INFO_H
+#define EDGEHOG_OS_INFO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <astarte_device.h>
+
+extern const astarte_interface_t os_info_interface;
+
+void edgehog_device_publish_os_info(astarte_device_handle_t astarte_device);
+#endif // EDGEHOG_OS_INFO_H

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -19,6 +19,7 @@
 #include "edgehog_battery_status.h"
 #include "edgehog_command.h"
 #include "edgehog_device_private.h"
+#include "edgehog_os_info.h"
 #include "edgehog_ota.h"
 #include "edgehog_storage_usage.h"
 #include "esp_system.h"
@@ -162,6 +163,7 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
     publish_system_status(edgehog_device);
     scan_wifi_ap(edgehog_device);
     edgehog_storage_usage_publish(edgehog_device->astarte_device);
+    edgehog_device_publish_os_info(edgehog_device->astarte_device);
     return edgehog_device;
 }
 
@@ -228,6 +230,13 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
             commands_interface.name, ret);
+        return ESP_FAIL;
+    }
+
+    ret = astarte_device_add_interface(device, &os_info_interface);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
+            os_info_interface.name, ret);
         return ESP_FAIL;
     }
 

--- a/src/edgehog_os_info.c
+++ b/src/edgehog_os_info.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_os_info.h"
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <esp_ota_ops.h>
+
+#define TAG "EDGEHOG_OS_INFO"
+
+const astarte_interface_t os_info_interface = { .name = "io.edgehog.devicemanager.OSInfo",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_PROPERTIES };
+
+void edgehog_device_publish_os_info(astarte_device_handle_t astarte_device)
+{
+    const esp_app_desc_t *app_info = esp_ota_get_app_description();
+    esp_err_t ret = astarte_device_set_string_property(
+        astarte_device, os_info_interface.name, "/osName", "esp-idf");
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to set osName property");
+        return;
+    }
+    ret = astarte_device_set_string_property(
+        astarte_device, os_info_interface.name, "/osVersion", esp_get_idf_version());
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to set osVersion property");
+    }
+}


### PR DESCRIPTION
Add support to OS info interface to send OS data to Astarte such as name and version.
As those data only change after an OTA, and therefore a reboot, they are only sent at boot and they are represented by properties because variations are quite infrequent.

Closes #28  

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>