### PR TITLE
Receive commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_ota.c"
         "src/edgehog_storage_usage.c"
-        "src/edgehog_battery_status.c")
+        "src/edgehog_battery_status.c"
+        "src/edgehog_command.c")
 
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"

--- a/private/edgehog_command.h
+++ b/private/edgehog_command.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_COMMAND_H
+#define EDGEHOG_COMMAND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "astarte_device.h"
+#include "edgehog.h"
+
+extern const astarte_interface_t commands_interface;
+
+/**
+ * @brief receive Edgehog device commands.
+ *
+ * @details This function receives a command request from Astarte.
+ *
+ * @param event_request A valid Astarte device data event.
+ *
+ * @return EDGEHOG_OK if the command event is handled successfully, an edgehog_err_t otherwise.
+ */
+
+edgehog_err_t edgehog_command_event(astarte_device_data_event_t *event_request);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EDGEHOG_COMMAND_H

--- a/src/edgehog_command.c
+++ b/src/edgehog_command.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_command.h"
+#include "astarte_bson.h"
+#include <astarte_bson_types.h>
+#include <esp_event.h>
+#include <esp_log.h>
+#include <string.h>
+
+static const char *TAG = "EDGEHOG_COMMANDS";
+
+const astarte_interface_t commands_interface = { .name = "io.edgehog.devicemanager.Commands",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM };
+
+edgehog_err_t edgehog_command_event(astarte_device_data_event_t *event_request)
+{
+    EDGEHOG_VALIDATE_INCOMING_DATA(TAG, event_request, "/request", BSON_TYPE_STRING);
+
+    size_t len;
+    const char *command = astarte_bson_value_to_string(event_request->bson_value, &len);
+
+    if (strcmp(command, "Reboot") == 0) {
+        ESP_LOGI(TAG, "Device will restart in 1 second");
+        vTaskDelay(pdMS_TO_TICKS(1000));
+        esp_restart();
+    } else {
+        ESP_LOGW(TAG, "Unable to handle command event, command %s unsupported", command);
+        return EDGEHOG_ERR;
+    }
+}

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -17,6 +17,7 @@
  */
 
 #include "edgehog_battery_status.h"
+#include "edgehog_command.h"
 #include "edgehog_device_private.h"
 #include "edgehog_ota.h"
 #include "edgehog_storage_usage.h"
@@ -119,6 +120,10 @@ void edgehog_device_astarte_event_handler(
             ESP_LOGI(TAG, "Device restart");
             esp_restart();
         }
+    } else if (strcmp(event->interface_name, commands_interface.name) == 0) {
+        if (edgehog_command_event(event) != EDGEHOG_OK) {
+            ESP_LOGE(TAG, "Unable to handle command request");
+        }
     }
 }
 
@@ -216,6 +221,13 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
             battery_status_interface.name, ret);
+        return ESP_FAIL;
+    }
+
+    ret = astarte_device_add_interface(device, &commands_interface);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
+            commands_interface.name, ret);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
Receive commands from server.

The command is received via the `io.edgehog.devicemanager.Commands`
interface.

The only supported command is Reboot at the moment.

Closes #30.