### PR TITLE
Add support to LedBehavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_command.c"
         "src/edgehog_os_info.c")
 
+if (${CONFIG_INDICATOR_GPIO_ENABLE})
+    set(edgehog_srcs ${edgehog_srcs} "src/edgehog_led.c")
+endif ()
+
 idf_component_register(SRCS "${edgehog_srcs}"
         INCLUDE_DIRS "include"
         PRIV_INCLUDE_DIRS "private"

--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,14 @@
+menu "Edgehog SDK"
+
+config INDICATOR_GPIO_ENABLE
+    bool "Activate Indicator LED GPIO"
+    default false
+    help
+        Set to true if a LED that can be used as an indicator is present.
+
+config INDICATOR_GPIO
+    int "Indicator LED GPIO"
+    depends on INDICATOR_GPIO_ENABLE
+    help
+        The GPIO number of the LED intended to be used as indicator.
+endmenu

--- a/include/edgehog.h
+++ b/include/edgehog.h
@@ -38,6 +38,7 @@ typedef enum
     EDGEHOG_ERR_OTA_FAILED = 5, /**< An error occurred during OTA procedure */
     EDGEHOG_ERR_OTA_DEPLOY = 6, /**< An error occurred during OTA Deploy procedure */
     EDGEHOG_ERR_OTA_WRONG_PARTITION = 7, /**< The OTA procedure boot on the wrong partition */
+    EDGEHOG_ERR_TASK_CREATE = 8, /**< xTaskCreate was unable to spawn a new task */
 }edgehog_err_t;
 
 // clang-format on

--- a/private/edgehog_led.h
+++ b/private/edgehog_led.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_LED_H
+#define EDGEHOG_LED_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "astarte_device.h"
+#include <edgehog.h>
+
+/**
+ * @brief Supported LED behaviors
+ *
+ * @details Enum defining the possible behaviors supported.
+ */
+typedef enum
+{
+    ON = 0, /**< Always ON - Only for Default behavior*/
+    OFF, /**< Always OFF - Only for Default behavior*/
+    BLINK, /**< Blinking behavior 1 sec. ON 1 sec, OFF*/
+    DOUBLE_BLINK, /**< Two small blink and 1 sec. OFF*/
+    SLOW_BLINK /**< Slow blinking behavior. 2 sec. ON 2 sec. OFF*/
+} led_behavior_t;
+
+struct edgehog_led_behavior_manager_t;
+
+typedef struct edgehog_led_behavior_manager_t *edgehog_led_behavior_manager_handle_t;
+
+extern const astarte_interface_t led_request_interface;
+
+/**
+ * @brief Create a new LED behavior manager
+ *
+ * @details Create and initialize a new LED behavior manager with OFF default behavior
+ *
+ * @return an handle for the led behavior manager
+ */
+edgehog_led_behavior_manager_handle_t edgehog_led_behavior_manager_new();
+
+/**
+ * @brief Set the default led behavior
+ *
+ * @details Sets a default behavior for the given LED. Only ON or OFF are currently supported
+ *
+ * @param led_manager Handle to the LED that has to be set
+ * @param default_behavior The default behavior between ON or OFF
+ */
+void edgehog_led_behavior_set_default(
+    edgehog_led_behavior_manager_handle_t led_manager, led_behavior_t default_behavior);
+
+/**
+ * @brief Handle function for a `io.edgehog.devicemanager.LedBehavior` message
+ *
+ * @details This function receives a LedBehavior message and sets the behavior described
+ * in the message for the number of seconds requested
+ *
+ * @param led_manager handle to the LED that has to be set
+ * @param event_request The request message
+ * @return EDGEHOG_OK if the message is correctly handled, EDGEHOG_ERR_TASK_CREATE otherwise.
+ */
+edgehog_err_t edgehog_led_behavior_event(
+    edgehog_led_behavior_manager_handle_t led_manager, astarte_device_data_event_t *event_request);
+
+#endif // EDGEHOG_LED_H

--- a/src/edgehog_led.c
+++ b/src/edgehog_led.c
@@ -1,0 +1,177 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_led.h"
+#include "driver/gpio.h"
+#include <astarte_bson.h>
+#include <astarte_bson_types.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <string.h>
+
+#define STACK_SIZE 2048
+
+static const char *TAG = "EDGEHOG_LED_BEHAVIOR";
+
+const astarte_interface_t led_request_interface = { .name = "io.edgehog.devicemanager.LedBehavior",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_SERVER,
+    .type = TYPE_DATASTREAM };
+
+typedef struct
+{
+    led_behavior_t behavior;
+    int duration_in_sec;
+    led_behavior_t default_behavior;
+    bool terminated;
+} led_behavior_config_t;
+
+struct edgehog_led_behavior_manager_t
+{
+    TaskHandle_t task_handle;
+    led_behavior_config_t *current_config;
+    led_behavior_t default_behavior;
+};
+
+edgehog_led_behavior_manager_handle_t edgehog_led_behavior_manager_new()
+{
+    // Set the pad as GPIO
+    gpio_pad_select_gpio(CONFIG_INDICATOR_GPIO);
+    // Set LED GPIO as output
+    gpio_set_direction(CONFIG_INDICATOR_GPIO, GPIO_MODE_OUTPUT);
+
+    edgehog_led_behavior_manager_handle_t led_behavior_handle
+        = calloc(1, sizeof(struct edgehog_led_behavior_manager_t));
+    if (!led_behavior_handle) {
+        ESP_LOGE(TAG, "Unable to allocate memory for led behavior manager handle");
+        return NULL;
+    }
+    led_behavior_handle->default_behavior = OFF;
+    return led_behavior_handle;
+}
+
+static void blinkTaskCode(void *pvParameters)
+{
+    led_behavior_config_t *params = (led_behavior_config_t *) pvParameters;
+    int64_t start_time = esp_timer_get_time();
+    ESP_LOGI(TAG, "Started behavior %d", params->behavior);
+    while ((esp_timer_get_time() - start_time) < (params->duration_in_sec * 1000000)) {
+        switch (params->behavior) {
+            case BLINK:
+                gpio_set_level(CONFIG_INDICATOR_GPIO, ON);
+                vTaskDelay(1000 / portTICK_RATE_MS);
+                gpio_set_level(CONFIG_INDICATOR_GPIO, OFF);
+                vTaskDelay(1000 / portTICK_RATE_MS);
+                break;
+            case DOUBLE_BLINK:
+                gpio_set_level(CONFIG_INDICATOR_GPIO, ON);
+                vTaskDelay(300 / portTICK_RATE_MS);
+                gpio_set_level(CONFIG_INDICATOR_GPIO, OFF);
+                vTaskDelay(200 / portTICK_RATE_MS);
+                gpio_set_level(CONFIG_INDICATOR_GPIO, ON);
+                vTaskDelay(300 / portTICK_RATE_MS);
+                gpio_set_level(CONFIG_INDICATOR_GPIO, OFF);
+                vTaskDelay(1000 / portTICK_RATE_MS);
+                break;
+            case SLOW_BLINK:
+                gpio_set_level(CONFIG_INDICATOR_GPIO, ON);
+                vTaskDelay(2000 / portTICK_RATE_MS);
+                gpio_set_level(CONFIG_INDICATOR_GPIO, OFF);
+                vTaskDelay(2000 / portTICK_RATE_MS);
+                break;
+            default:
+                ESP_LOGE(TAG, "Unexpected Led behavior %d", params->behavior);
+                goto loop_end;
+        }
+    }
+
+loop_end:
+    params->terminated = true;
+    gpio_set_level(CONFIG_INDICATOR_GPIO, params->default_behavior);
+    ESP_LOGI(TAG, "Task ended gracefully by timeout");
+    vTaskDelete(NULL);
+    free(params);
+}
+
+static edgehog_err_t set_led_behavior(
+    edgehog_led_behavior_manager_handle_t led_manager, led_behavior_t behavior, int duration_in_sec)
+{
+    if (led_manager->current_config) {
+        if (!led_manager->current_config->terminated && led_manager->task_handle) {
+            ESP_LOGI(TAG, "New behavior received before previous ended. Previous Task killed");
+            vTaskDelete(led_manager->task_handle);
+        }
+        free(led_manager->current_config);
+        led_manager->current_config = NULL;
+    }
+
+    led_manager->current_config = malloc(sizeof(led_behavior_config_t));
+    if (!led_manager->current_config) {
+        ESP_LOGE(TAG, "Unable to allocate memory for led behavior config");
+        return EDGEHOG_ERR;
+    }
+    led_manager->current_config->behavior = behavior;
+    led_manager->current_config->duration_in_sec = duration_in_sec;
+    led_manager->current_config->default_behavior = led_manager->default_behavior;
+    led_manager->current_config->terminated = false;
+
+    BaseType_t ret = xTaskCreate(blinkTaskCode, "NAME", STACK_SIZE, led_manager->current_config,
+        tskIDLE_PRIORITY, &led_manager->task_handle);
+
+    if (ret != pdPASS) {
+        free(led_manager->current_config);
+        return EDGEHOG_ERR_TASK_CREATE;
+    }
+
+    ESP_LOGI(TAG, "Task handle: %p", led_manager->task_handle);
+    return EDGEHOG_OK;
+}
+
+void edgehog_led_behavior_set_default(
+    edgehog_led_behavior_manager_handle_t led_manager, led_behavior_t default_behavior)
+{
+    if (default_behavior != ON && default_behavior != OFF) {
+        ESP_LOGE(TAG, "Only ON and OFF behavior are supported as default");
+    }
+
+    led_manager->default_behavior = default_behavior;
+    gpio_set_level(CONFIG_INDICATOR_GPIO, default_behavior);
+}
+
+edgehog_err_t edgehog_led_behavior_event(
+    edgehog_led_behavior_manager_handle_t led_manager, astarte_device_data_event_t *event_request)
+{
+    EDGEHOG_VALIDATE_INCOMING_DATA(TAG, event_request, "/indicator/behavior", BSON_TYPE_STRING);
+
+    size_t str_value_len;
+    const char *request_behavior
+        = astarte_bson_value_to_string(event_request->bson_value, &str_value_len);
+
+    if (strcmp(request_behavior, "Blink60Seconds") == 0) {
+        return set_led_behavior(led_manager, BLINK, 60);
+    } else if (strcmp(request_behavior, "DoubleBlink60Seconds") == 0) {
+        return set_led_behavior(led_manager, DOUBLE_BLINK, 60);
+    } else if (strcmp(request_behavior, "SlowBlink60Seconds") == 0) {
+        return set_led_behavior(led_manager, SLOW_BLINK, 60);
+    }
+
+    ESP_LOGE(TAG, "Unable to handle led behavior request, behavior not supported");
+    return EDGEHOG_ERR;
+}


### PR DESCRIPTION
- Add support to the parametric datastream path `/%{led_id}/behavior` of the `io.edgehog.devicemanager.LedBehavior` server-owned datastream interface.
At the current state, the only supported `led_id` is `indicator`.
The supported values are the following:

| value | behavior | Duration |
| --- | --- | --- |
| Blink60Seconds | Blink | 60 sec. |
| DoubleBlink60Seconds | Double blink | 60 sec. |
| SlowBlink60Seconds | Slow blink | 60 sec. |

- Add a Kconfig file for the edgehog-esp32-device component containing two configs:
    - `INDICATOR_GPIO_ACTIVATION`: `boolean` activate the indicator LED behavior support
    - `INDICATOR_GPIO`: [depends on `INDICATOR_GPIO_ACTIVATION`] `int` set the indicator LED GPIO number.

Close #29 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>