### PR TITLE
Add support to OSBundle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_storage_usage.c"
         "src/edgehog_battery_status.c"
         "src/edgehog_command.c"
-        "src/edgehog_os_info.c")
+        "src/edgehog_os_info.c"
+        "src/edgehog_os_bundle.c")
 
 if (${CONFIG_INDICATOR_GPIO_ENABLE})
     set(edgehog_srcs ${edgehog_srcs} "src/edgehog_led.c")

--- a/examples/edgehog_app/CMakeLists.txt
+++ b/examples/edgehog_app/CMakeLists.txt
@@ -6,4 +6,7 @@ include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 set(EXTRA_COMPONENT_DIRS ${CMAKE_SOURCE_DIR}/../..)
 set(PROJECT_VER "0.1.0")
+
+string(TIMESTAMP BUILD_DATE_TIME "%Y%m%d%H%M%S")
+add_definitions(-DBUILD_DATE_TIME="${BUILD_DATE_TIME}")
 project(edgehog-app)

--- a/private/edgehog_os_bundle.h
+++ b/private/edgehog_os_bundle.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_OS_IMAGE_H
+#define EDGEHOG_OS_IMAGE_H
+#include <astarte_device.h>
+#include <esp_err.h>
+
+extern const astarte_interface_t os_bundle_interface;
+
+/**
+ * @brief Publish OS Image data
+ *
+ * @details This function fetches and publishes Firmware-specific data
+ * @param astarte_device A valid Astarte device handle.
+ */
+void edgehog_os_bundle_data_publish(astarte_device_handle_t astarte_device);
+
+#endif // EDGEHOG_OS_IMAGE_H

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -23,6 +23,7 @@
 #if CONFIG_INDICATOR_GPIO_ENABLE
 #include "edgehog_led.h"
 #endif
+#include "edgehog_os_bundle.h"
 #include "edgehog_ota.h"
 #include "edgehog_storage_usage.h"
 #include "esp_system.h"
@@ -183,6 +184,7 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
 #if CONFIG_INDICATOR_GPIO_ENABLE
     edgehog_device->led_manager = edgehog_led_behavior_manager_new();
 #endif
+    edgehog_os_bundle_data_publish(edgehog_device->astarte_device);
     return edgehog_device;
 }
 
@@ -264,6 +266,13 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
             os_info_interface.name, ret);
+        return ESP_FAIL;
+    }
+
+    ret = astarte_device_add_interface(device, &os_bundle_interface);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
+            os_bundle_interface.name, ret);
         return ESP_FAIL;
     }
 

--- a/src/edgehog_os_bundle.c
+++ b/src/edgehog_os_bundle.c
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2021 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_os_bundle.h"
+#include <esp_log.h>
+#include <esp_ota_ops.h>
+#include <string.h>
+#ifdef BUILD_DATE_TIME
+
+#define BUILD_ID BUILD_DATE_TIME
+#else
+#define BUILD_ID ""
+#endif
+
+static const char *TAG = "EDGEHOG_OS_IMAGE";
+
+const astarte_interface_t os_bundle_interface = { .name = "io.edgehog.devicemanager.OSBundle",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_PROPERTIES };
+
+void edgehog_os_bundle_data_publish(astarte_device_handle_t astarte_device)
+{
+    const esp_app_desc_t *desc = esp_ota_get_app_description();
+
+    astarte_err_t ret = astarte_device_set_string_property(
+        astarte_device, os_bundle_interface.name, "/name", desc->project_name);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish os image name");
+        return;
+    }
+
+    ret = astarte_device_set_string_property(
+        astarte_device, os_bundle_interface.name, "/version", desc->version);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish os image version");
+        return;
+    }
+
+    ret = astarte_device_set_string_property(
+        astarte_device, os_bundle_interface.name, "/buildId", BUILD_ID);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish os image build id");
+        return;
+    }
+
+    char sha256_str[65];
+    esp_ota_get_app_elf_sha256(sha256_str, 65);
+    ret = astarte_device_set_string_property(
+        astarte_device, os_bundle_interface.name, "/fingerprint", sha256_str);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish os image hash");
+    }
+}


### PR DESCRIPTION
Add support to the `io.edgehog.devicemanager.OSBundle` interface to publish firmware-specific data retrieved using the `esp_ota_get_app_description()` function.

While `/name`, `/version` and `/fingerprint` are fetched directly from the said description, `buildId` is computed from the `BUILD_DATE_TIME`  definition in the Makefile.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>