### PR TITLE
Add Astarte path and type checking macro

### DIFF
--- a/include/edgehog.h
+++ b/include/edgehog.h
@@ -42,4 +42,12 @@ typedef enum
 
 // clang-format on
 
+#define EDGEHOG_VALIDATE_INCOMING_DATA(TAG, EVENT_REQUEST, PATH, BSON_TYPE)                        \
+    if ((EVENT_REQUEST)->bson_value_type != (BSON_TYPE)                                            \
+        || strcmp((EVENT_REQUEST)->path, (PATH)) != 0) {                                           \
+        ESP_LOGE(TAG, "Unable to handle request on %s having type code %i", (EVENT_REQUEST)->path, \
+            (EVENT_REQUEST)->bson_value_type);                                                     \
+        return EDGEHOG_ERR;                                                                        \
+    }
+
 #endif // EDGEHOG_H

--- a/src/edgehog_ota.c
+++ b/src/edgehog_ota.c
@@ -149,10 +149,7 @@ end:
 edgehog_err_t edgehog_ota_event(edgehog_device_handle_t edgehog_device,
     astarte_device_handle_t astarte_device, astarte_device_data_event_t *event_request)
 {
-    if (event_request->bson_value_type != BSON_TYPE_DOCUMENT) {
-        ESP_LOGE(TAG, "Unable to handle ota request, type not supported");
-        return EDGEHOG_ERR;
-    }
+    EDGEHOG_VALIDATE_INCOMING_DATA(TAG, event_request, "/request", BSON_TYPE_DOCUMENT);
 
     uint8_t type;
     size_t str_value_len;


### PR DESCRIPTION
Add EDGEHOG_VALIDATE_INCOMING_DATA for checking incoming requests.

It is possible to check incoming requests from Astarte doing something like:
```c
EDGEHOG_VALIDATE_INCOMING_DATA(TAG, event_request, "/request", BSON_TYPE_DOCUMENT);
```