### PR TITLE
Add support to RuntimeInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,8 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_command.c"
         "src/edgehog_os_info.c"
         "src/edgehog_os_bundle.c"
-        "src/edgehog_telemetry.c")
+        "src/edgehog_telemetry.c"
+        "src/edgehog_runtime_info.c")
 
 if (${CONFIG_INDICATOR_GPIO_ENABLE})
     set(edgehog_srcs ${edgehog_srcs} "src/edgehog_led.c")

--- a/private/edgehog_runtime_info.h
+++ b/private/edgehog_runtime_info.h
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_RUNTIME_INFO_H
+#define EDGEHOG_RUNTIME_INFO_H
+
+#include "edgehog_device.h"
+
+extern const astarte_interface_t runtime_info_interface;
+
+/**
+ * @brief Publish runtime info
+ *
+ * @details This function fetches and publishes the edgehog runtime info to Astarte
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ */
+void edgehog_runtime_info_publish(edgehog_device_handle_t edgehog_device);
+
+#endif // EDGEHOG_RUNTIME_INFO_H

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -22,6 +22,7 @@
 #include "edgehog_os_bundle.h"
 #include "edgehog_os_info.h"
 #include "edgehog_ota.h"
+#include "edgehog_runtime_info.h"
 #include "edgehog_storage_usage.h"
 #include "esp_system.h"
 #include <astarte_bson_serializer.h>
@@ -185,6 +186,7 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
     }
     edgehog_device->edgehog_telemetry = edgehog_telemetry;
 
+    edgehog_runtime_info_publish(edgehog_device);
     return edgehog_device;
 
 error:
@@ -294,6 +296,13 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
             os_bundle_interface.name, ret);
+        return ESP_FAIL;
+    }
+
+    ret = astarte_device_add_interface(device, &runtime_info_interface);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
+            runtime_info_interface.name, ret);
         return ESP_FAIL;
     }
 

--- a/src/edgehog_runtime_info.c
+++ b/src/edgehog_runtime_info.c
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_runtime_info.h"
+#include "edgehog_device_private.h"
+#include <esp_idf_version.h>
+#include <esp_log.h>
+#include <stdio.h>
+#include <string.h>
+
+#define RUNTIME_NAME "edgehog-esp32-device"
+#define RUNTIME_URL "https://github.com/edgehog-device-manager/edgehog-esp32-device"
+#define RUNTIME_VERSION "0.1.0"
+
+static const char *TAG = "EDGEHOG_RUNTIME_INFO";
+
+const astarte_interface_t runtime_info_interface = { .name = "io.edgehog.devicemanager.RuntimeInfo",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_PROPERTIES };
+
+void edgehog_runtime_info_publish(edgehog_device_handle_t edgehog_device)
+{
+    astarte_device_handle_t astarte_device = edgehog_device->astarte_device;
+    astarte_err_t ret = astarte_device_set_string_property(
+        astarte_device, runtime_info_interface.name, "/name", RUNTIME_NAME);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish runtime name");
+        return;
+    }
+    ret = astarte_device_set_string_property(
+        astarte_device, runtime_info_interface.name, "/url", RUNTIME_URL);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish runtime URL");
+        return;
+    }
+    ret = astarte_device_set_string_property(
+        astarte_device, runtime_info_interface.name, "/version", RUNTIME_VERSION);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish runtime version");
+        return;
+    }
+
+    const char *idf_version = esp_get_idf_version();
+    size_t env_size = strlen(idf_version) + strlen("esp-idf ") + 1;
+    char *environment = malloc(env_size);
+    if (!environment) {
+        ESP_LOGE(TAG, "Unable to allocate memory for environment");
+        return;
+    }
+    snprintf(environment, env_size, "esp-idf %s", idf_version);
+    ret = astarte_device_set_string_property(
+        astarte_device, runtime_info_interface.name, "/environment", environment);
+    if (ret != ASTARTE_OK) {
+        ESP_LOGE(TAG, "Unable to publish runtime environment");
+    }
+    free(environment);
+}


### PR DESCRIPTION
Add support to the `io.edgehog.devicemanager.RuntimeInfo` to publish info regarding the edgehog runtime.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>