### PR TITLE
Add software timer support

### DIFF
--- a/src/edgehog_telemetry.c
+++ b/src/edgehog_telemetry.c
@@ -18,33 +18,34 @@
 
 #include "edgehog_telemetry.h"
 #include "astarte_bson.h"
+#include "astarte_list.h"
 #include "edgehog_device_private.h"
 #include <astarte_bson_types.h>
 #include <esp_log.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
+#include <freertos/timers.h>
 #include <string.h>
 
-#define TASK_NAME_PREFIX "eht"
-// task_name_prefix + 1 (p or e) + 1 (1-9 telemetry_type) increment this if telemetry_type is
+#define NVS_KEY_PREFIX "eht"
+// nvs_key_prefix + 1 (p or e) + 1 (1-9 telemetry_type) increment this if telemetry_type is
 // greater than 9
-#define TASK_NAME_SIZE 6
+#define NVS_KEY_SIZE 6
 #define NVS_KEY_PERIOD(telemetry_type)                                                             \
-    char period_key[TASK_NAME_SIZE];                                                               \
-    snprintf(period_key, TASK_NAME_SIZE, "%sp%hhd", TASK_NAME_PREFIX, (int8_t) telemetry_type)
+    char period_key[NVS_KEY_SIZE];                                                                 \
+    snprintf(period_key, NVS_KEY_SIZE, "%sp%hhd", NVS_KEY_PREFIX, (int8_t) telemetry_type)
 
 #define NVS_KEY_ENABLE(telemetry_type)                                                             \
-    char enable_key[TASK_NAME_SIZE];                                                               \
-    snprintf(enable_key, TASK_NAME_SIZE, "%se%hhd", TASK_NAME_PREFIX, (int8_t) telemetry_type)
+    char enable_key[NVS_KEY_SIZE];                                                                 \
+    snprintf(enable_key, NVS_KEY_SIZE, "%se%hhd", NVS_KEY_PREFIX, (int8_t) telemetry_type)
 
-#define GET_TELEMETRY_INDEX(telemetry_type) ((int) telemetry_type - 1)
-#define GET_TELEMETRY_TYPE(telemetry_index) ((telemetry_type_t)(telemetry_index + 1))
+#define GET_TELEMETRY_TYPE(enable_key)                                                             \
+    telemetry_type_t telemetry_type                                                                \
+        = (telemetry_type_t) strtol(&enable_entry_info.key[4], NULL, 10);
 
 #define TELEMETRY_NAMESPACE "ehgd_tlm"
 
-// The telemetry update array length, increment this when add item to telemetry_type_t
-#define TELEMETRY_TASK_PARAM_LEN 4
 #define TELEMETRY_UPDATE_DEFAULT 0
 #define TELEMETRY_UPDATE_DISABLED -1
 #define TELEMETRY_UPDATE_ENABLED 1
@@ -58,42 +59,38 @@ const astarte_interface_t telemetry_config_interface
           .ownership = OWNERSHIP_SERVER,
           .type = TYPE_PROPERTIES };
 
-struct telemetry_task_param
+typedef struct astarte_list_head_t timer_list_head_t;
+
+struct timer_ptr_entry_t
 {
+    timer_list_head_t head;
     edgehog_device_handle_t edgehog_device;
-    telemetry_type_t type;
-    int64_t period_seconds;
-    TaskHandle_t x_handle;
+    telemetry_type_t telemetry_type;
+    TimerHandle_t timer_handle;
 };
 
 struct edgehog_telemetry_data
 {
     SemaphoreHandle_t load_tl_mutex;
-    struct telemetry_task_param tl_params[TELEMETRY_TASK_PARAM_LEN];
     edgehog_device_telemetry_config_t *telemetry_config;
+    timer_list_head_t timer_list;
     size_t telemetry_config_len;
 };
 
-static void telemetry_loop(void *task_param);
-static struct telemetry_task_param *get_telemetry_task_param(
-    edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type);
-static edgehog_err_t save_telemetry_task_param_to_nvs(
-    edgehog_device_handle_t edgehog_device, struct telemetry_task_param *telemetry_task_param);
-static edgehog_err_t telemetry_schedule(
-    edgehog_device_handle_t edgehog_device, struct telemetry_task_param *telemetry_task_param);
+static edgehog_err_t save_telemetry_to_nvs(edgehog_device_handle_t edgehog_device,
+    telemetry_type_t telemetry_type, int64_t period_seconds);
+static edgehog_err_t telemetry_schedule(edgehog_device_handle_t edgehog_device,
+    telemetry_type_t telemetry_type, int64_t period_seconds);
 static bool telemetry_type_is_present_in_config(
     edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type);
 static int64_t get_telemetry_period_from_config(
     edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type);
-static void load_telemetry_task_params_from_config(
-    edgehog_device_handle_t edgehog_device, edgehog_telemetry_t *edgehog_telemetry);
-static void load_telemetry_task_params_from_nvs(
-    edgehog_device_handle_t edgehog_device, edgehog_telemetry_t *edgehog_telemetry);
-static bool is_task_created(xTaskHandle handle);
-static void telemetry_update_init(
-    struct telemetry_task_param *telemetry_task_param, telemetry_type_t telemetry_type);
+static void load_telemetry_from_config(edgehog_device_handle_t edgehog_device);
+static void load_telemetry_from_nvs(edgehog_device_handle_t edgehog_device);
 static int64_t get_telemetry_period_from_nvs(
     edgehog_device_handle_t edgehog_device, telemetry_type_t telemetry_type);
+static struct timer_ptr_entry_t *get_timer_entry(
+    edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type);
 
 edgehog_telemetry_t *edgehog_telemetry_new(
     edgehog_device_telemetry_config_t *telemetry_config, size_t telemetry_config_len)
@@ -111,25 +108,19 @@ edgehog_telemetry_t *edgehog_telemetry_new(
         goto error;
     }
 
-    for (int i = 0; i < TELEMETRY_TASK_PARAM_LEN; i++) {
-        telemetry_update_init(
-            &edgehog_telemetry->tl_params[i], (telemetry_type_t) GET_TELEMETRY_TYPE(i));
-    }
+    edgehog_telemetry->telemetry_config_len = telemetry_config_len;
 
-    if (telemetry_config_len > 0) {
-        edgehog_telemetry->telemetry_config_len = telemetry_config_len;
-
-        edgehog_telemetry->telemetry_config = calloc(
-            edgehog_telemetry->telemetry_config_len, sizeof(edgehog_device_telemetry_config_t));
-        if (!edgehog_telemetry->telemetry_config) {
-            ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
-            goto error;
-        }
-        memcpy(edgehog_telemetry->telemetry_config, telemetry_config,
-            telemetry_config_len * sizeof(edgehog_device_telemetry_config_t));
-    } else {
-        edgehog_telemetry->telemetry_config_len = 0;
+    edgehog_telemetry->telemetry_config = calloc(
+        edgehog_telemetry->telemetry_config_len, sizeof(edgehog_device_telemetry_config_t));
+    if (!edgehog_telemetry->telemetry_config) {
+        ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+        goto error;
     }
+    memcpy(edgehog_telemetry->telemetry_config, telemetry_config,
+        telemetry_config_len * sizeof(edgehog_device_telemetry_config_t));
+
+    astarte_list_init(&edgehog_telemetry->timer_list);
+
     return edgehog_telemetry;
 
 error:
@@ -154,66 +145,80 @@ edgehog_err_t edgehog_telemetry_start(
         return EDGEHOG_ERR_DEVICE_NOT_READY;
     }
 
-    load_telemetry_task_params_from_config(edgehog_device, edgehog_telemetry);
-    load_telemetry_task_params_from_nvs(edgehog_device, edgehog_telemetry);
-
-    for (int i = 0; i < TELEMETRY_TASK_PARAM_LEN; i++) {
-        struct telemetry_task_param *telemetry_task_param = &edgehog_telemetry->tl_params[i];
-        save_telemetry_task_param_to_nvs(edgehog_device, telemetry_task_param);
-        telemetry_schedule(edgehog_device, telemetry_task_param);
-    }
+    load_telemetry_from_nvs(edgehog_device);
+    load_telemetry_from_config(edgehog_device);
 
     xSemaphoreGive(edgehog_telemetry->load_tl_mutex);
     return EDGEHOG_OK;
 }
 
-static edgehog_err_t telemetry_schedule(
-    edgehog_device_handle_t edgehog_device, struct telemetry_task_param *telemetry_task_param)
+static void timer_callback(TimerHandle_t timer_handle)
 {
-    bool is_created = is_task_created(telemetry_task_param->x_handle);
-    if (is_created) {
-        vTaskDelete(telemetry_task_param->x_handle);
-        ESP_LOGI(TAG, "Telemetry tl_updates type %d removed", telemetry_task_param->type);
-    }
+    struct timer_ptr_entry_t *timer_entry
+        = (struct timer_ptr_entry_t *) pvTimerGetTimerID(timer_handle);
+    telemetry_periodic telemetry_periodic_fn
+        = edgehog_device_get_telemetry_periodic(timer_entry->telemetry_type);
+    telemetry_periodic_fn(timer_entry->edgehog_device);
+}
 
-    telemetry_task_param->x_handle = NULL;
-
-    if (telemetry_task_param->period_seconds <= 0) {
-        save_telemetry_task_param_to_nvs(edgehog_device, telemetry_task_param);
-        return EDGEHOG_OK;
-    }
-
-    if (telemetry_task_param->type <= EDGEHOG_TELEMETRY_INVALID) {
-        ESP_LOGE(TAG, "Telemetry tl_updates invalid %d", telemetry_task_param->type);
+static edgehog_err_t telemetry_schedule(
+    edgehog_device_handle_t edgehog_device, telemetry_type_t telemetry_type, int64_t period_seconds)
+{
+    if (telemetry_type <= EDGEHOG_TELEMETRY_INVALID) {
+        ESP_LOGE(TAG, "Telemetry type invalid %d", telemetry_type);
         goto error;
     }
 
-    NVS_KEY_ENABLE(telemetry_task_param->type);
-    if (xTaskCreate(telemetry_loop, enable_key, 4096, telemetry_task_param, tskIDLE_PRIORITY,
-            &telemetry_task_param->x_handle)
-        != pdPASS) {
-        telemetry_task_param->period_seconds = TELEMETRY_UPDATE_DISABLED;
-        save_telemetry_task_param_to_nvs(edgehog_device, telemetry_task_param);
-        goto error;
+    NVS_KEY_ENABLE(telemetry_type);
+    struct timer_ptr_entry_t *timer_entry
+        = get_timer_entry(edgehog_device->edgehog_telemetry, telemetry_type);
+
+    if (!timer_entry) {
+        if (period_seconds <= 0) {
+            ESP_LOGW(TAG, "timer %d disabled", telemetry_type);
+            return EDGEHOG_OK;
+        }
+
+        timer_entry = calloc(1, sizeof(struct timer_ptr_entry_t));
+        if (!timer_entry) {
+            ESP_LOGE(TAG, "Unable to create timer entry %s", enable_key);
+            goto error;
+        }
+
+        timer_entry->edgehog_device = edgehog_device;
+        timer_entry->telemetry_type = telemetry_type;
+
+        timer_entry->timer_handle = xTimerCreate(NULL, pdMS_TO_TICKS(period_seconds * 1000), pdTRUE,
+            (void *) timer_entry, timer_callback);
+        if (!timer_entry->timer_handle) {
+            ESP_LOGE(TAG, "Unable to create timer %s", enable_key);
+            free(timer_entry);
+            goto error;
+        }
+
+        if (xTimerStart(timer_entry->timer_handle, 0) != pdPASS) {
+            ESP_LOGW(TAG, "The timer %s could not be set into the Active state", enable_key);
+            xTimerDelete(timer_entry->timer_handle, 0);
+            free(timer_entry);
+            save_telemetry_to_nvs(edgehog_device, telemetry_type, TELEMETRY_UPDATE_DISABLED);
+            goto error;
+        }
+
+        astarte_list_append(&edgehog_device->edgehog_telemetry->timer_list, &timer_entry->head);
+    } else if (period_seconds > 0) {
+        xTimerChangePeriod(timer_entry->timer_handle, pdMS_TO_TICKS(period_seconds * 1000), 0);
+    } else {
+        xTimerDelete(timer_entry->timer_handle, 0);
+        astarte_list_remove(&timer_entry->head);
+        ESP_LOGI(TAG, "Telemetry type %d removed", telemetry_type);
     }
 
+    save_telemetry_to_nvs(edgehog_device, telemetry_type, period_seconds);
     return EDGEHOG_OK;
 
 error:
     ESP_LOGE(TAG, "Unable to schedule new telemetry");
     return EDGEHOG_ERR;
-}
-
-static void telemetry_loop(void *task_param)
-{
-    struct telemetry_task_param *param = (struct telemetry_task_param *) task_param;
-    ESP_LOGI(
-        TAG, "Telemetry active on type %d every %lld seconds", param->type, param->period_seconds);
-    telemetry_periodic periodic_fn = edgehog_device_get_telemetry_periodic(param->type);
-    for (;;) {
-        periodic_fn(param->edgehog_device);
-        vTaskDelay(pdMS_TO_TICKS(param->period_seconds * 1000));
-    }
 }
 
 edgehog_err_t edgehog_telemetry_config_event(astarte_device_data_event_t *event_request,
@@ -241,19 +246,13 @@ edgehog_err_t edgehog_telemetry_config_event(astarte_device_data_event_t *event_
         return EDGEHOG_ERR;
     }
 
-    struct telemetry_task_param *telemetry_task_param
-        = get_telemetry_task_param(edgehog_telemetry, telemetry_type);
-    if (!telemetry_task_param) {
-        ESP_LOGE(TAG, "Unable to update telemetry for type %d", telemetry_type);
-        return EDGEHOG_ERR;
-    }
-
     if (xSemaphoreTake(edgehog_telemetry->load_tl_mutex, (TickType_t) 10) == pdFALSE) {
         ESP_LOGE(
             TAG, "Trying to handle config telemetry event on device that is being initialized");
         return EDGEHOG_ERR_DEVICE_NOT_READY;
     }
 
+    int64_t period_seconds = get_telemetry_period_from_nvs(edgehog_device, telemetry_type);
     if (strcmp(endpoint, "enable") == 0) {
         bool enable;
         if (event_request->bson_value && event_request->bson_value_type == BSON_TYPE_BOOLEAN) {
@@ -262,16 +261,10 @@ edgehog_err_t edgehog_telemetry_config_event(astarte_device_data_event_t *event_
             enable = telemetry_type_is_present_in_config(edgehog_telemetry, telemetry_type);
         }
 
-        if (enable) {
-            telemetry_task_param->period_seconds
-                = get_telemetry_period_from_nvs(edgehog_device, telemetry_type);
-        } else {
-            telemetry_task_param->period_seconds = TELEMETRY_UPDATE_DISABLED;
+        if (!enable) {
+            period_seconds = TELEMETRY_UPDATE_DISABLED;
         }
-
-        save_telemetry_task_param_to_nvs(edgehog_device, telemetry_task_param);
     } else if (strcmp(endpoint, "periodSeconds") == 0) {
-        int64_t period_seconds;
         if (event_request->bson_value && event_request->bson_value_type >= BSON_TYPE_INT32) {
             if (event_request->bson_value_type == BSON_TYPE_INT32) {
                 period_seconds = astarte_bson_value_to_int32(event_request->bson_value);
@@ -281,12 +274,9 @@ edgehog_err_t edgehog_telemetry_config_event(astarte_device_data_event_t *event_
         } else {
             period_seconds = get_telemetry_period_from_config(edgehog_telemetry, telemetry_type);
         }
-
-        telemetry_task_param->period_seconds = period_seconds;
-        save_telemetry_task_param_to_nvs(edgehog_device, telemetry_task_param);
     }
 
-    telemetry_schedule(edgehog_device, telemetry_task_param);
+    telemetry_schedule(edgehog_device, telemetry_type, period_seconds);
     xSemaphoreGive(edgehog_telemetry->load_tl_mutex);
 
     return EDGEHOG_OK;
@@ -295,51 +285,27 @@ edgehog_err_t edgehog_telemetry_config_event(astarte_device_data_event_t *event_
 void edgehog_telemetry_destroy(edgehog_telemetry_t *edgehog_telemetry)
 {
     if (edgehog_telemetry) {
-        for (int i = 0; i < TELEMETRY_TASK_PARAM_LEN; i++) {
-            if (is_task_created(edgehog_telemetry->tl_params[i].x_handle)) {
-                vTaskDelete(edgehog_telemetry->tl_params[i].x_handle);
+
+        timer_list_head_t *item, *tmp;
+        MUTABLE_LIST_FOR_EACH(item, tmp, &edgehog_telemetry->timer_list)
+        {
+            struct timer_ptr_entry_t *entry = GET_LIST_ENTRY(item, struct timer_ptr_entry_t, head);
+            if (xTimerIsTimerActive(entry->timer_handle)) {
+                xTimerDelete(entry->timer_handle, 0);
             }
+            free(entry);
         }
-        free(edgehog_telemetry->tl_params);
+
         free(edgehog_telemetry->telemetry_config);
         vSemaphoreDelete(edgehog_telemetry->load_tl_mutex);
         free(edgehog_telemetry);
     }
 }
 
-static bool is_task_created(xTaskHandle handle)
+static edgehog_err_t save_telemetry_to_nvs(
+    edgehog_device_handle_t edgehog_device, telemetry_type_t telemetry_type, int64_t period_seconds)
 {
-    if (!handle) {
-        return false;
-    }
-
-    const char *task_get_name = pcTaskGetTaskName(handle);
-    return task_get_name && strlen(task_get_name) > 0;
-}
-
-static struct telemetry_task_param *get_telemetry_task_param(
-    edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type)
-{
-    int task_handle_index = GET_TELEMETRY_INDEX(telemetry_type);
-    if (task_handle_index == -1) {
-        ESP_LOGE(TAG, "Unable to get telemetry, type unsupported");
-        return NULL;
-    }
-    return &edgehog_telemetry->tl_params[task_handle_index];
-}
-
-static void telemetry_update_init(
-    struct telemetry_task_param *telemetry_task_param, telemetry_type_t telemetry_type)
-{
-    telemetry_task_param->type = telemetry_type;
-    telemetry_task_param->x_handle = NULL;
-    telemetry_task_param->period_seconds = TELEMETRY_UPDATE_DEFAULT;
-}
-
-static edgehog_err_t save_telemetry_task_param_to_nvs(
-    edgehog_device_handle_t edgehog_device, struct telemetry_task_param *telemetry_task_param)
-{
-    if (telemetry_task_param->type <= EDGEHOG_TELEMETRY_INVALID) {
+    if (telemetry_type <= EDGEHOG_TELEMETRY_INVALID) {
         ESP_LOGE(TAG, "Unable to save telemetry tl_updates invalid type");
         return EDGEHOG_ERR;
     }
@@ -352,13 +318,12 @@ static edgehog_err_t save_telemetry_task_param_to_nvs(
         ESP_LOGW(TAG, "Unable to open NVS to save new telemetry update");
         edgehog_result = EDGEHOG_ERR;
     } else {
-
-        NVS_KEY_ENABLE(telemetry_task_param->type);
-        if (telemetry_task_param->period_seconds > 0) {
+        NVS_KEY_ENABLE(telemetry_type);
+        if (period_seconds > 0) {
             nvs_set_i8(nvs_handle, enable_key, TELEMETRY_UPDATE_ENABLED);
-            NVS_KEY_PERIOD(telemetry_task_param->type);
-            nvs_set_i64(nvs_handle, period_key, telemetry_task_param->period_seconds);
-        } else if (telemetry_task_param->period_seconds < 0) {
+            NVS_KEY_PERIOD(telemetry_type);
+            nvs_set_i64(nvs_handle, period_key, period_seconds);
+        } else if (period_seconds < 0) {
             nvs_set_i8(nvs_handle, enable_key, TELEMETRY_UPDATE_DISABLED);
         } else {
             nvs_set_i8(nvs_handle, enable_key, TELEMETRY_UPDATE_DEFAULT);
@@ -410,25 +375,21 @@ static int64_t get_telemetry_period_from_nvs(
     return period_seconds;
 }
 
-static void load_telemetry_task_params_from_config(
-    edgehog_device_handle_t edgehog_device, edgehog_telemetry_t *edgehog_telemetry)
+static void load_telemetry_from_config(edgehog_device_handle_t edgehog_device)
 {
+    edgehog_telemetry_t *edgehog_telemetry = edgehog_device->edgehog_telemetry;
     for (int i = 0; i < edgehog_telemetry->telemetry_config_len; i++) {
-        struct telemetry_task_param *telemetry_task_param = get_telemetry_task_param(
-            edgehog_telemetry, edgehog_telemetry->telemetry_config[i].type);
-
-        if (!telemetry_task_param) {
-            continue;
+        edgehog_device_telemetry_config_t telemetry_config = edgehog_telemetry->telemetry_config[i];
+        struct timer_ptr_entry_t *timer_entry
+            = get_timer_entry(edgehog_device->edgehog_telemetry, telemetry_config.type);
+        if (!timer_entry) {
+            telemetry_schedule(
+                edgehog_device, telemetry_config.type, telemetry_config.period_seconds);
         }
-
-        telemetry_task_param->period_seconds
-            = edgehog_telemetry->telemetry_config[i].period_seconds;
-        telemetry_task_param->edgehog_device = edgehog_device;
     }
 }
 
-static void load_telemetry_task_params_from_nvs(
-    edgehog_device_handle_t edgehog_device, edgehog_telemetry_t *edgehog_telemetry)
+static void load_telemetry_from_nvs(edgehog_device_handle_t edgehog_device)
 {
     nvs_handle_t nvs_handle;
     esp_err_t result = edgehog_device_nvs_open(edgehog_device, TELEMETRY_NAMESPACE, &nvs_handle);
@@ -438,30 +399,53 @@ static void load_telemetry_task_params_from_nvs(
         return;
     }
 
-    for (int i = 0; i < TELEMETRY_TASK_PARAM_LEN; i++) {
-        telemetry_type_t telemetry_type = (telemetry_type_t) GET_TELEMETRY_TYPE(i);
-        struct telemetry_task_param *telemetry_task_param
-            = get_telemetry_task_param(edgehog_telemetry, telemetry_type);
-        if (!telemetry_task_param) {
-            ESP_LOGE(TAG, "Unable to update telemetry for type %d", telemetry_type);
+    for (nvs_iterator_t it
+         = edgehog_device_nvs_entry_find(edgehog_device, TELEMETRY_NAMESPACE, NVS_TYPE_I8);
+         it; it = nvs_entry_next(it)) {
+        nvs_entry_info_t enable_entry_info;
+        nvs_entry_info(it, &enable_entry_info);
+
+        if (strncmp(enable_entry_info.key, NVS_KEY_PREFIX, strlen(NVS_KEY_PREFIX)) != 0) {
             continue;
         }
 
-        NVS_KEY_ENABLE(telemetry_type);
+        GET_TELEMETRY_TYPE(enable_entry_info.key);
         NVS_KEY_PERIOD(telemetry_type);
         int8_t enable = TELEMETRY_UPDATE_DEFAULT;
-        nvs_get_i8(nvs_handle, enable_key, &enable);
+        nvs_get_i8(nvs_handle, enable_entry_info.key, &enable);
+
+        if (enable == TELEMETRY_UPDATE_DEFAULT) {
+            continue;
+        }
+
         int64_t period_seconds = TELEMETRY_UPDATE_DEFAULT;
         nvs_get_i64(nvs_handle, period_key, &period_seconds);
-        if (enable == TELEMETRY_UPDATE_ENABLED) {
-            telemetry_task_param->period_seconds = period_seconds;
-            telemetry_task_param->edgehog_device = edgehog_device;
+
+        if (enable == TELEMETRY_UPDATE_DISABLED) {
+            period_seconds = TELEMETRY_UPDATE_DISABLED;
+        } else {
             ESP_LOGI(TAG, "Load telemetry config type %d %d %lld from nvs", telemetry_type, enable,
                 period_seconds);
-        } else if (enable == TELEMETRY_UPDATE_DISABLED) {
-            telemetry_task_param->period_seconds = TELEMETRY_UPDATE_DISABLED;
         }
+
+        telemetry_schedule(edgehog_device, telemetry_type, period_seconds);
     }
 
     nvs_close(nvs_handle);
+}
+
+static struct timer_ptr_entry_t *get_timer_entry(
+    edgehog_telemetry_t *edgehog_telemetry, telemetry_type_t telemetry_type)
+{
+    timer_list_head_t *item;
+    NVS_KEY_ENABLE(telemetry_type);
+    LIST_FOR_EACH(item, &edgehog_telemetry->timer_list)
+    {
+        struct timer_ptr_entry_t *entry = GET_LIST_ENTRY(item, struct timer_ptr_entry_t, head);
+        TimerHandle_t timer_handle = entry->timer_handle;
+        if (timer_handle && telemetry_type == entry->telemetry_type) {
+            return entry;
+        }
+    }
+    return NULL;
 }


### PR DESCRIPTION
Add FreeRTOS software timer support

Timer callback functions execute in the context of the timer service task. It is therefore essential that timer callback functions never attempt to block.