### PR TITLE
Rename OSBundle to BaseImage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_battery_status.c"
         "src/edgehog_command.c"
         "src/edgehog_os_info.c"
-        "src/edgehog_os_bundle.c"
+        "src/edgehog_base_image.c"
         "src/edgehog_telemetry.c"
         "src/edgehog_runtime_info.c")
 

--- a/private/edgehog_base_image.h
+++ b/private/edgehog_base_image.h
@@ -21,14 +21,14 @@
 #include <edgehog_device.h>
 #include <esp_err.h>
 
-extern const astarte_interface_t os_bundle_interface;
+extern const astarte_interface_t base_image_interface;
 
 /**
- * @brief Publish OS Image data
+ * @brief Publish Base Image data
  *
  * @details This function fetches and publishes Firmware-specific data
  * @param edgehog_device A valid Edgehog device handle.
  */
-void edgehog_os_bundle_data_publish(edgehog_device_handle_t edgehog_device);
+void edgehog_base_image_data_publish(edgehog_device_handle_t edgehog_device);
 
 #endif // EDGEHOG_OS_IMAGE_H

--- a/src/edgehog_base_image.c
+++ b/src/edgehog_base_image.c
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "edgehog_os_bundle.h"
+#include "edgehog_base_image.h"
 #include "edgehog_device_private.h"
 #include <esp_log.h>
 #include <esp_ota_ops.h>
@@ -27,35 +27,35 @@
 #define BUILD_ID ""
 #endif
 
-static const char *TAG = "EDGEHOG_OS_IMAGE";
+static const char *TAG = "EDGEHOG_BASE_IMAGE";
 
-const astarte_interface_t os_bundle_interface = { .name = "io.edgehog.devicemanager.OSBundle",
+const astarte_interface_t base_image_interface = { .name = "io.edgehog.devicemanager.BaseImage",
     .major_version = 0,
     .minor_version = 1,
     .ownership = OWNERSHIP_DEVICE,
     .type = TYPE_PROPERTIES };
 
-void edgehog_os_bundle_data_publish(edgehog_device_handle_t edgehog_device)
+void edgehog_base_image_data_publish(edgehog_device_handle_t edgehog_device)
 {
     const esp_app_desc_t *desc = esp_ota_get_app_description();
     astarte_device_handle_t astarte_device = edgehog_device->astarte_device;
 
     astarte_err_t ret = astarte_device_set_string_property(
-        astarte_device, os_bundle_interface.name, "/name", desc->project_name);
+        astarte_device, base_image_interface.name, "/name", desc->project_name);
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to publish os image name");
         return;
     }
 
     ret = astarte_device_set_string_property(
-        astarte_device, os_bundle_interface.name, "/version", desc->version);
+        astarte_device, base_image_interface.name, "/version", desc->version);
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to publish os image version");
         return;
     }
 
     ret = astarte_device_set_string_property(
-        astarte_device, os_bundle_interface.name, "/buildId", BUILD_ID);
+        astarte_device, base_image_interface.name, "/buildId", BUILD_ID);
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to publish os image build id");
         return;
@@ -64,7 +64,7 @@ void edgehog_os_bundle_data_publish(edgehog_device_handle_t edgehog_device)
     char sha256_str[65];
     esp_ota_get_app_elf_sha256(sha256_str, 65);
     ret = astarte_device_set_string_property(
-        astarte_device, os_bundle_interface.name, "/fingerprint", sha256_str);
+        astarte_device, base_image_interface.name, "/fingerprint", sha256_str);
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to publish os image hash");
     }

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -16,10 +16,10 @@
  * limitations under the License.
  */
 
+#include "edgehog_base_image.h"
 #include "edgehog_battery_status.h"
 #include "edgehog_command.h"
 #include "edgehog_device_private.h"
-#include "edgehog_os_bundle.h"
 #include "edgehog_os_info.h"
 #include "edgehog_ota.h"
 #include "edgehog_runtime_info.h"
@@ -177,7 +177,7 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
 #if CONFIG_INDICATOR_GPIO_ENABLE
     edgehog_device->led_manager = edgehog_led_behavior_manager_new();
 #endif
-    edgehog_os_bundle_data_publish(edgehog_device);
+    edgehog_base_image_data_publish(edgehog_device);
     edgehog_telemetry_t *edgehog_telemetry
         = edgehog_telemetry_new(config->telemetry_config, config->telemetry_config_len);
     if (!edgehog_telemetry) {
@@ -292,10 +292,10 @@ esp_err_t add_interfaces(astarte_device_handle_t device)
         return ESP_FAIL;
     }
 
-    ret = astarte_device_add_interface(device, &os_bundle_interface);
+    ret = astarte_device_add_interface(device, &base_image_interface);
     if (ret != ASTARTE_OK) {
         ESP_LOGE(TAG, "Unable to add Astarte Interface ( %s ) error code: %d",
-            os_bundle_interface.name, ret);
+            base_image_interface.name, ret);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
Update the interface name from `io.edgehog.devicemanager.OSBundle` to `io.edgehog.devicemanager.BaseImage`.
Change the various filenames to reflect the new naming.

Close #46 

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>