### PR TITLE
Move scan_wifi_ap function

### DIFF
--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -173,7 +173,6 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
     edgehog_ota_init(edgehog_device);
     publish_device_hardware_info(edgehog_device);
     publish_system_status(edgehog_device);
-    scan_wifi_ap(edgehog_device);
     edgehog_storage_usage_publish(edgehog_device);
     edgehog_device_publish_os_info(edgehog_device);
 #if CONFIG_INDICATOR_GPIO_ENABLE
@@ -189,6 +188,7 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
     edgehog_device->edgehog_telemetry = edgehog_telemetry;
 
     edgehog_runtime_info_publish(edgehog_device);
+    scan_wifi_ap(edgehog_device);
     return edgehog_device;
 
 error:


### PR DESCRIPTION
In some cases sending messages overlaps generating a discard of other messages.
This problem was generated by the asynchronous `scan_wifi_ap` function,
 moving it to the end of `edgehog_device_new` end reduces it.
This is a temporary fix until the issue will be resolved.
[Astarte Device SDK  ESP32 Issue](https://github.com/astarte-platform/astarte-device-sdk-esp32/issues/85)