### PR TITLE
Fix docs

### DIFF
--- a/include/edgehog.h
+++ b/include/edgehog.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog.h
+ * @brief Edgehog types and defines.
+ */
+
 #ifndef EDGEHOG_H
 #define EDGEHOG_H
 

--- a/include/edgehog_battery_status.h
+++ b/include/edgehog_battery_status.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog_battery_status.h
+ * @brief Edgehog device battery status API.
+ */
+
 #ifndef EDGEHOG_BATTERY_STATUS_H
 #define EDGEHOG_BATTERY_STATUS_H
 

--- a/include/edgehog_cellular_connection.h
+++ b/include/edgehog_cellular_connection.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog_cellular_connection.h
+ * @brief Edgehog device cellular connection API.
+ */
+
 #ifndef EDGEHOG_CELLULAR_CONNECTION_H
 #define EDGEHOG_CELLULAR_CONNECTION_H
 

--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog_device.h
+ * @brief Edgehog device SDK API.
+ */
+
 #ifndef EDGEHOG_DEVICE_H
 #define EDGEHOG_DEVICE_H
 

--- a/include/edgehog_event.h
+++ b/include/edgehog_event.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog_event.h
+ * Edgehog events definitions.
+ */
+
 #ifndef EDGEHOG_EVENT_H
 #define EDGEHOG_EVENT_H
 

--- a/include/edgehog_network_interface.h
+++ b/include/edgehog_network_interface.h
@@ -16,6 +16,11 @@
  * limitations under the License.
  */
 
+/**
+ * @file edgehog_network_interface.h
+ * @brief Edgehog device network interface API.
+ */
+
 #ifndef EDGEHOG_NETWORK_INTERFACE_H
 #define EDGEHOG_NETWORK_INTERFACE_H
 


### PR DESCRIPTION
Add `@file` markers in order to tell doxygen to generate documentation for public headers.