### PR TITLE
Decouple battery update and publish logic, and make it future-proof

### DIFF
--- a/include/edgehog_battery_status.h
+++ b/include/edgehog_battery_status.h
@@ -49,6 +49,13 @@ typedef enum
     BATTERY_UNKNOWN /**< The battery state for the device cannot be determined. */
 } edgehog_battery_state;
 
+typedef struct {
+    const char *battery_slot; /**< Battery slot name. */
+    double level_percentage; /**< Charge level in [0.0%-100.0%] range, such as 89.0%. */
+    double level_absolute_error; /**< The level measurement absolute error in [0.0-100.0] range. */
+    edgehog_battery_state battery_state; /**< Any value of edgehog_battery_state such as `BATTERY_CHARGING`. */
+} edgehog_battery_status_t;
+
 // clang-format on
 
 extern const astarte_interface_t battery_status_interface;
@@ -63,13 +70,11 @@ void edgehog_battery_status_delete_list(struct astarte_list_head_t *battery_list
  * the update.
  *
  * @param edgehog_device A valid Edgehog device handle.
- * @param battery_slot Battery slot name.
- * @param level_percentage Charge level in [0.0%-100.0%] range, such as 89.0%.
- * @param level_absolute_error The level measurement absolute error in [0.0-100.0] range
- * @param state Any value of edgehog_battery_state such as `BATTERY_CHARGING`
+ * @param battery_status A battery status structure that contains current battery status. It can be
+ * safely allocated on the stack, a copy of it is automatically stored.
  */
-void edgehog_battery_status_update(edgehog_device_handle_t edgehog_device, const char *battery_slot,
-    double level_percentage, double level_absolute_error, edgehog_battery_state state);
+void edgehog_battery_status_update(
+    edgehog_device_handle_t edgehog_device, const edgehog_battery_status_t *battery_status);
 
 /**
  * @brief Publish battery status info.

--- a/include/edgehog_battery_status.h
+++ b/include/edgehog_battery_status.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of Edgehog.
  *
- * Copyright 2021 SECO Mind Srl
+ * Copyright 2021,2022 SECO Mind Srl
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ extern "C" {
 
 #include "edgehog_device.h"
 
+#include <astarte_list.h>
+
 // clang-format off
 
 /**
@@ -51,22 +53,32 @@ typedef enum
 
 extern const astarte_interface_t battery_status_interface;
 
+// Private API
+void edgehog_battery_status_delete_list(struct astarte_list_head_t *battery_list);
+
 /**
- * @brief publish Battery status info.
+ * @brief Update battery status info.
  *
- * @details This function publishes battery status info
- * to Astarte.
+ * @details This function updates battery status info. This function does not immediately publish
+ * the update.
  *
  * @param edgehog_device A valid Edgehog device handle.
  * @param battery_slot Battery slot name.
  * @param level_percentage Charge level in [0.0%-100.0%] range, such as 89.0%.
  * @param level_absolute_error The level measurement absolute error in [0.0-100.0] range
  * @param state Any value of edgehog_battery_state such as `BATTERY_CHARGING`
- *
  */
-void edgehog_battery_status_publish(edgehog_device_handle_t edgehog_device,
-    const char *battery_slot, double level_percentage, double level_absolute_error,
-    edgehog_battery_state state);
+void edgehog_battery_status_update(edgehog_device_handle_t edgehog_device, const char *battery_slot,
+    double level_percentage, double level_absolute_error, edgehog_battery_state state);
+
+/**
+ * @brief Publish battery status info.
+ *
+ * @details This function publishes to Astarte all available battery status updates.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ */
+void edgehog_battery_status_publish(edgehog_device_handle_t edgehog_device);
 
 #ifdef __cplusplus
 }

--- a/include/edgehog_battery_status.h
+++ b/include/edgehog_battery_status.h
@@ -30,8 +30,6 @@ extern "C" {
 
 #include "edgehog_device.h"
 
-#include <astarte_list.h>
-
 // clang-format off
 
 /**
@@ -57,11 +55,6 @@ typedef struct {
 } edgehog_battery_status_t;
 
 // clang-format on
-
-extern const astarte_interface_t battery_status_interface;
-
-// Private API
-void edgehog_battery_status_delete_list(struct astarte_list_head_t *battery_list);
 
 /**
  * @brief Update battery status info.

--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -47,7 +47,8 @@ typedef enum
     EDGEHOG_TELEMETRY_HW_INFO = 1, /**< The hardware info telemetry type. */
     EDGEHOG_TELEMETRY_WIFI_SCAN = 2, /**< The wifi scan telemetry type. */
     EDGEHOG_TELEMETRY_SYSTEM_STATUS = 3, /**< The system status telemetry type. */
-    EDGEHOG_TELEMETRY_STORAGE_USAGE = 4 /**< The storage usage telemetry type. */
+    EDGEHOG_TELEMETRY_STORAGE_USAGE = 4, /**< The storage usage telemetry type. */
+    EDGEHOG_TELEMETRY_BATTERY_STATUS = 5 /**< The battery status telemetry type. */
 } telemetry_type_t;
 
 /**

--- a/private/edgehog_battery_status_p.h
+++ b/private/edgehog_battery_status_p.h
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_BATTERY_STATUS_P_H
+#define EDGEHOG_BATTERY_STATUS_P_H
+
+#include "edgehog_device.h"
+
+#include <astarte_list.h>
+
+/**
+ * Private API.
+ */
+
+extern const astarte_interface_t battery_status_interface;
+
+void edgehog_battery_status_delete_list(struct astarte_list_head_t *battery_list);
+
+#endif // EDGEHOG_BATTERY_STATUS_P_H

--- a/private/edgehog_device_private.h
+++ b/private/edgehog_device_private.h
@@ -29,6 +29,8 @@ extern "C" {
 #include "edgehog_led.h"
 #endif
 
+#include <astarte_list.h>
+
 struct edgehog_device_t
 {
     char boot_id[ASTARTE_UUID_LEN];
@@ -38,6 +40,8 @@ struct edgehog_device_t
     edgehog_led_behavior_manager_handle_t led_manager;
 #endif
     edgehog_telemetry_t *edgehog_telemetry;
+
+    struct astarte_list_head_t battery_list;
 };
 
 /**

--- a/src/edgehog_battery_status.c
+++ b/src/edgehog_battery_status.c
@@ -17,6 +17,7 @@
  */
 
 #include "edgehog_battery_status.h"
+#include "edgehog_battery_status_p.h"
 #include "edgehog_device_private.h"
 #include <astarte_bson_serializer.h>
 #include <esp_log.h>

--- a/src/edgehog_battery_status.c
+++ b/src/edgehog_battery_status.c
@@ -92,18 +92,18 @@ static struct battery_status_t *get_battery_status(
     return status;
 }
 
-void edgehog_battery_status_update(edgehog_device_handle_t edgehog_device, const char *battery_slot,
-    double level_percentage, double level_absolute_error, edgehog_battery_state battery_state)
+void edgehog_battery_status_update(
+    edgehog_device_handle_t edgehog_device, const edgehog_battery_status_t *update)
 {
-    struct battery_status_t *status = get_battery_status(edgehog_device, battery_slot);
+    struct battery_status_t *status = get_battery_status(edgehog_device, update->battery_slot);
     if (!status) {
         ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
         return;
     }
 
-    status->level_percentage = normalize_error_level(level_percentage);
-    status->level_absolute_error = normalize_error_level(level_absolute_error);
-    status->battery_state = battery_state;
+    status->level_percentage = normalize_error_level(update->level_percentage);
+    status->level_absolute_error = normalize_error_level(update->level_absolute_error);
+    status->battery_state = update->battery_state;
 }
 
 void edgehog_battery_status_publish(edgehog_device_handle_t edgehog_device)

--- a/src/edgehog_battery_status.c
+++ b/src/edgehog_battery_status.c
@@ -31,37 +31,112 @@ const astarte_interface_t battery_status_interface
           .ownership = OWNERSHIP_DEVICE,
           .type = TYPE_DATASTREAM };
 
+struct battery_status_t
+{
+    struct astarte_list_head_t head;
+    char *battery_slot;
+    double level_percentage;
+    double level_absolute_error;
+    edgehog_battery_state battery_state;
+};
+
 static const char *edgehog_battery_to_code(edgehog_battery_state state);
 static double normalize_error_level(double level);
 
-void edgehog_battery_status_publish(edgehog_device_handle_t edgehog_device,
-    const char *battery_slot, double level_percentage, double level_absolute_error,
-    edgehog_battery_state battery_state)
+void edgehog_battery_status_delete_list(struct astarte_list_head_t *battery_list)
 {
-    const char *battery_status = edgehog_battery_to_code(battery_state);
-    struct astarte_bson_serializer_t bs;
-    astarte_bson_serializer_init(&bs);
-    astarte_bson_serializer_append_double(
-        &bs, "levelPercentage", normalize_error_level(level_percentage));
-    astarte_bson_serializer_append_double(
-        &bs, "levelAbsoluteError", normalize_error_level(level_absolute_error));
-    astarte_bson_serializer_append_string(&bs, "status", battery_status);
-    astarte_bson_serializer_append_end_of_document(&bs);
+    struct astarte_list_head_t *item;
+    struct astarte_list_head_t *tmp;
+    MUTABLE_LIST_FOR_EACH(item, tmp, battery_list)
+    {
+        struct battery_status_t *status = GET_LIST_ENTRY(item, struct battery_status_t, head);
+        free(status->battery_slot);
+        free(status);
+    }
+}
 
-    size_t path_size = strlen(battery_slot) + 2;
-    char *path = malloc(path_size);
-    if (!path) {
+static struct battery_status_t *find_battery(
+    struct astarte_list_head_t *battery_list, const char *battery_slot)
+{
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, battery_list)
+    {
+        struct battery_status_t *status = GET_LIST_ENTRY(item, struct battery_status_t, head);
+        if (strcmp(status->battery_slot, battery_slot) == 0) {
+            return status;
+        }
+    }
+
+    return NULL;
+}
+
+static struct battery_status_t *get_battery_status(
+    edgehog_device_handle_t edgehog_device, const char *battery_slot)
+{
+    struct battery_status_t *status = find_battery(&edgehog_device->battery_list, battery_slot);
+    if (!status) {
+        status = calloc(1, sizeof(struct battery_status_t));
+        if (!status) {
+            return NULL;
+        }
+
+        status->battery_slot = strdup(battery_slot);
+        if (!status->battery_slot) {
+            free(status);
+            return NULL;
+        }
+
+        astarte_list_append(&edgehog_device->battery_list, &status->head);
+    }
+
+    return status;
+}
+
+void edgehog_battery_status_update(edgehog_device_handle_t edgehog_device, const char *battery_slot,
+    double level_percentage, double level_absolute_error, edgehog_battery_state battery_state)
+{
+    struct battery_status_t *status = get_battery_status(edgehog_device, battery_slot);
+    if (!status) {
         ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
         return;
     }
-    snprintf(path, path_size, "/%s", battery_slot);
 
-    int doc_len;
-    const void *doc = astarte_bson_serializer_get_document(&bs, &doc_len);
-    astarte_device_stream_aggregate(
-        edgehog_device->astarte_device, battery_status_interface.name, path, doc, 0);
-    astarte_bson_serializer_destroy(&bs);
-    free(path);
+    status->level_percentage = normalize_error_level(level_percentage);
+    status->level_absolute_error = normalize_error_level(level_absolute_error);
+    status->battery_state = battery_state;
+}
+
+void edgehog_battery_status_publish(edgehog_device_handle_t edgehog_device)
+{
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, &edgehog_device->battery_list)
+    {
+        struct battery_status_t *battery = GET_LIST_ENTRY(item, struct battery_status_t, head);
+
+        struct astarte_bson_serializer_t bs;
+        astarte_bson_serializer_init(&bs);
+        astarte_bson_serializer_append_double(&bs, "levelPercentage", battery->level_percentage);
+        astarte_bson_serializer_append_double(
+            &bs, "levelAbsoluteError", battery->level_absolute_error);
+        const char *battery_status = edgehog_battery_to_code(battery->battery_state);
+        astarte_bson_serializer_append_string(&bs, "status", battery_status);
+        astarte_bson_serializer_append_end_of_document(&bs);
+
+        size_t path_size = strlen(battery->battery_slot) + 2;
+        char *path = malloc(path_size);
+        if (!path) {
+            ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+            return;
+        }
+        snprintf(path, path_size, "/%s", battery->battery_slot);
+
+        int doc_len;
+        const void *doc = astarte_bson_serializer_get_document(&bs, &doc_len);
+        astarte_device_stream_aggregate(
+            edgehog_device->astarte_device, battery_status_interface.name, path, doc, 0);
+        astarte_bson_serializer_destroy(&bs);
+        free(path);
+    }
 }
 
 static const char *edgehog_battery_to_code(edgehog_battery_state state)

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -169,6 +169,8 @@ edgehog_device_handle_t edgehog_device_new(edgehog_device_config_t *config)
         edgehog_device->partition_name = NVS_DEFAULT_PART_NAME;
     }
 
+    astarte_list_init(&edgehog_device->battery_list);
+
     ESP_ERROR_CHECK(add_interfaces(config->astarte_device));
     edgehog_ota_init(edgehog_device);
     publish_device_hardware_info(edgehog_device);
@@ -499,6 +501,7 @@ void edgehog_device_destroy(edgehog_device_handle_t edgehog_device)
 {
     if (edgehog_device) {
         astarte_device_destroy(edgehog_device->astarte_device);
+        edgehog_battery_status_delete_list(&edgehog_device->battery_list);
         edgehog_telemetry_destroy(edgehog_device->edgehog_telemetry);
     }
 

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -538,6 +538,8 @@ telemetry_periodic edgehog_device_get_telemetry_periodic(telemetry_type_t type)
             return publish_system_status;
         case EDGEHOG_TELEMETRY_STORAGE_USAGE:
             return edgehog_storage_usage_publish;
+        case EDGEHOG_TELEMETRY_BATTERY_STATUS:
+            return edgehog_battery_status_publish;
         default:
             return NULL;
     }
@@ -553,6 +555,8 @@ telemetry_type_t edgehog_device_get_telemetry_type(const char *interface_name)
         return EDGEHOG_TELEMETRY_SYSTEM_STATUS;
     } else if (strcmp(interface_name, storage_usage_interface.name) == 0) {
         return EDGEHOG_TELEMETRY_STORAGE_USAGE;
+    } else if (strcmp(interface_name, battery_status_interface.name) == 0) {
+        return EDGEHOG_TELEMETRY_BATTERY_STATUS;
     } else {
         return EDGEHOG_TELEMETRY_INVALID;
     }

--- a/src/edgehog_device.c
+++ b/src/edgehog_device.c
@@ -18,6 +18,7 @@
 
 #include "edgehog_base_image.h"
 #include "edgehog_battery_status.h"
+#include "edgehog_battery_status_p.h"
 #include "edgehog_cellular_connection.h"
 #include "edgehog_command.h"
 #include "edgehog_device_private.h"


### PR DESCRIPTION
Decouple battery update and publish, so update can be safely called several times per second.