### PR TITLE
Add support to GPS data interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ set(edgehog_srcs "src/edgehog_device.c"
         "src/edgehog_telemetry.c"
         "src/edgehog_runtime_info.c"
         "src/edgehog_cellular_connection.c"
-        "src/edgehog_network_interface.c")
+        "src/edgehog_network_interface.c"
+        "src/edgehog_geolocation.c")
 
 if (${CONFIG_INDICATOR_GPIO_ENABLE})
     set(edgehog_srcs ${edgehog_srcs} "src/edgehog_led.c")

--- a/include/edgehog_device.h
+++ b/include/edgehog_device.h
@@ -48,7 +48,8 @@ typedef enum
     EDGEHOG_TELEMETRY_WIFI_SCAN = 2, /**< The wifi scan telemetry type. */
     EDGEHOG_TELEMETRY_SYSTEM_STATUS = 3, /**< The system status telemetry type. */
     EDGEHOG_TELEMETRY_STORAGE_USAGE = 4, /**< The storage usage telemetry type. */
-    EDGEHOG_TELEMETRY_BATTERY_STATUS = 5 /**< The battery status telemetry type. */
+    EDGEHOG_TELEMETRY_BATTERY_STATUS = 5, /**< The battery status telemetry type. */
+    EDGEHOG_TELEMETRY_GEOLOCATION_INFO = 6 /**< The storage usage telemetry type. */
 } telemetry_type_t;
 
 /**

--- a/include/edgehog_geolocation.h
+++ b/include/edgehog_geolocation.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_GEOLOCATION_H
+#define EDGEHOG_GEOLOCATION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "edgehog_device.h"
+
+/**
+ * @brief Edgehog geolocation Data struct
+ */
+typedef struct
+{
+    const char *id; /* GPS receiver identifier */
+    double longitude; /* Sampled longitude value. */
+    double latitude; /* Sampled latitude value. */
+    double accuracy; /* Sampled accuracy of the latitude and longitude properties. */
+    double altitude; /* Sampled altitude value. */
+    double altitude_accuracy; /* Sampled accuracy of the altitude property. */
+    double heading; /*Sampled value of the direction towards which the device is facing. */
+    double speed; /*Sampled value representing the velocity of the device.*/
+} edgehog_geolocation_data_t;
+
+/**
+ * @brief Publish geolocation data.
+ *
+ * @details This function publishes to Astarte all available geolocation data updates.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ */
+void edgehog_geolocation_publish(edgehog_device_handle_t edgehog_device);
+
+/**
+ * @brief Update geolocation info
+ *
+ * @details This function updates geolocation data. This function does not immediately publish
+ * the update.
+ *
+ * @param edgehog_device A valid Edgehog device handle.
+ * @param battery_status A geolocation data structure that contains current geolocation. It can be
+ * safely allocated on the stack, a copy of it is automatically stored.
+ */
+void edgehog_geolocation_update(
+    edgehog_device_handle_t edgehog_device, edgehog_geolocation_data_t *update);
+#endif // EDGEHOG_GEOLOCATION_H

--- a/private/edgehog_device_private.h
+++ b/private/edgehog_device_private.h
@@ -42,6 +42,7 @@ struct edgehog_device_t
     edgehog_telemetry_t *edgehog_telemetry;
 
     struct astarte_list_head_t battery_list;
+    struct astarte_list_head_t geolocation_list;
 };
 
 /**

--- a/private/edgehog_geolocation_p.h
+++ b/private/edgehog_geolocation_p.h
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EDGEHOG_GEOLOCATION_P_H
+#define EDGEHOG_GEOLOCATION_P_H
+#include "edgehog_device.h"
+#include <astarte_list.h>
+
+// clang-format on
+
+extern const astarte_interface_t geolocation_interface;
+
+void edgehog_geolocation_delete_list(struct astarte_list_head_t *geolocation_list);
+
+#endif // EDGEHOG_GEOLOCATION_P_H

--- a/src/edgehog_geolocation.c
+++ b/src/edgehog_geolocation.c
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Edgehog.
+ *
+ * Copyright 2022 SECO Mind Srl
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "edgehog_geolocation.h"
+#include "astarte_bson_serializer.h"
+#include "edgehog_device_private.h"
+#include "edgehog_geolocation_p.h"
+#include <esp_log.h>
+
+static const char *TAG = "EDGEHOG_GEOLOCATION";
+
+const astarte_interface_t geolocation_interface = { .name = "io.edgehog.devicemanager.Geolocation",
+    .major_version = 0,
+    .minor_version = 1,
+    .ownership = OWNERSHIP_DEVICE,
+    .type = TYPE_DATASTREAM };
+
+struct geolocation_info_t
+{
+    struct astarte_list_head_t head;
+    bool updated;
+    char *id;
+    double longitude;
+    double latitude;
+    double accuracy;
+    double altitude;
+    double altitude_accuracy;
+    double heading;
+    double speed;
+};
+
+void edgehog_geolocation_delete_list(struct astarte_list_head_t *geolocation_list)
+{
+    struct astarte_list_head_t *item;
+    struct astarte_list_head_t *tmp;
+    MUTABLE_LIST_FOR_EACH(item, tmp, geolocation_list)
+    {
+        struct geolocation_info_t *status = GET_LIST_ENTRY(item, struct geolocation_info_t, head);
+        free(status->id);
+        free(status);
+    }
+}
+
+static struct geolocation_info_t *find_geolocation(
+    struct astarte_list_head_t *geolocation_list, const char *gps_id)
+{
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, geolocation_list)
+    {
+        struct geolocation_info_t *status = GET_LIST_ENTRY(item, struct geolocation_info_t, head);
+        if (strcmp(status->id, gps_id) == 0) {
+            return status;
+        }
+    }
+
+    return NULL;
+}
+
+static struct geolocation_info_t *get_geolocation_info(
+    edgehog_device_handle_t edgehog_device, const char *gps_id)
+{
+    struct geolocation_info_t *status = find_geolocation(&edgehog_device->geolocation_list, gps_id);
+    if (!status) {
+        status = calloc(1, sizeof(struct geolocation_info_t));
+        if (!status) {
+            return NULL;
+        }
+
+        status->updated = false;
+        status->id = strdup(gps_id);
+        status->longitude = 0;
+        status->latitude = 0;
+        status->accuracy = 0;
+        status->altitude = 0;
+        status->altitude_accuracy = 0;
+        status->heading = 0;
+        status->speed = 0;
+        if (!status->id) {
+            free(status);
+            return NULL;
+        }
+
+        astarte_list_append(&edgehog_device->geolocation_list, &status->head);
+    }
+
+    return status;
+}
+
+void edgehog_geolocation_update(
+    edgehog_device_handle_t edgehog_device, edgehog_geolocation_data_t *update)
+{
+    struct geolocation_info_t *status = get_geolocation_info(edgehog_device, update->id);
+    if (!status) {
+        ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+        return;
+    }
+
+    if (!status->updated
+        && (status->longitude != update->longitude || status->latitude != update->latitude
+            || status->accuracy != update->accuracy || status->altitude != update->altitude
+            || status->altitude_accuracy != update->altitude_accuracy
+            || status->heading != update->heading || status->speed != update->speed)) {
+        status->updated = true;
+        status->longitude = update->longitude;
+        status->latitude = update->latitude;
+        status->accuracy = update->accuracy;
+        status->altitude = update->altitude;
+        status->altitude_accuracy = update->altitude_accuracy;
+        status->heading = update->heading;
+        status->speed = update->speed;
+    }
+}
+
+void edgehog_geolocation_publish(edgehog_device_handle_t edgehog_device)
+{
+    struct astarte_list_head_t *item;
+    LIST_FOR_EACH(item, &edgehog_device->geolocation_list)
+    {
+        struct geolocation_info_t *data = GET_LIST_ENTRY(item, struct geolocation_info_t, head);
+
+        if (!data->updated) {
+            continue;
+        }
+        struct astarte_bson_serializer_t bs;
+        astarte_bson_serializer_init(&bs);
+        astarte_bson_serializer_append_double(&bs, "latitude", data->latitude);
+        astarte_bson_serializer_append_double(&bs, "longitude", data->longitude);
+        astarte_bson_serializer_append_double(&bs, "accuracy", data->accuracy);
+        astarte_bson_serializer_append_double(&bs, "altitude", data->altitude);
+        astarte_bson_serializer_append_double(&bs, "altitudeAccuracy", data->altitude_accuracy);
+        astarte_bson_serializer_append_double(&bs, "heading", data->heading);
+        astarte_bson_serializer_append_double(&bs, "speed", data->speed);
+        astarte_bson_serializer_append_end_of_document(&bs);
+
+        size_t path_size = strlen(data->id) + 2;
+        char *path = malloc(path_size);
+        if (!path) {
+            ESP_LOGE(TAG, "Out of memory %s: %d", __FILE__, __LINE__);
+            return;
+        }
+        snprintf(path, path_size, "/%s", data->id);
+
+        int doc_len;
+        const void *doc = astarte_bson_serializer_get_document(&bs, &doc_len);
+        astarte_err_t res = astarte_device_stream_aggregate(
+            edgehog_device->astarte_device, geolocation_interface.name, path, doc, 0);
+
+        astarte_bson_serializer_destroy(&bs);
+        free(path);
+
+        if (res == ASTARTE_OK) {
+            data->updated = false;
+        }
+    }
+}


### PR DESCRIPTION
Add support to `io.edgehog.devicemanager.Geolocation` to publish positioning information.

Signed-off-by: Francesco Vaiani <francesco.vaiani@secomind.com>